### PR TITLE
Add integrated GoogleTest support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
 
     - name: Build with Make
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,9 +60,11 @@ include_directories(
     src
 )
 
+# Enable testing infrastructure
+include(CTest)
+
 # Source Files
-set(SOURCES
-    src/main.cpp
+set(ZTAIL_LIB_SOURCES
     src/circular_buffer.cpp
     src/cli.cpp
     src/compressor_zlib.cpp
@@ -70,12 +72,39 @@ set(SOURCES
     src/parser.cpp
 )
 
-# Executable
-add_executable(ztail ${SOURCES})
-
-# Link Libraries
-target_link_libraries(ztail
-    PRIVATE
+# Build library with core functionality
+add_library(ztail_lib ${ZTAIL_LIB_SOURCES})
+target_link_libraries(ztail_lib
+    PUBLIC
         ${ZLIB_LIBRARIES}
         ${LIBZIP_LIBRARIES}
 )
+target_include_directories(ztail_lib PUBLIC src)
+
+# Executable
+add_executable(ztail src/main.cpp)
+target_link_libraries(ztail PRIVATE ztail_lib)
+
+# ------------------------------------------------------------------------------
+# Tests
+if(BUILD_TESTING)
+    include(FetchContent)
+    FetchContent_Declare(
+        googletest
+        URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+    )
+    FetchContent_MakeAvailable(googletest)
+
+    enable_testing()
+
+    add_executable(ztail_tests
+        tests/test_circular_buffer.cpp
+        tests/test_compressor_zlib.cpp
+        tests/test_compressor_zip.cpp
+        tests/test_parser.cpp
+    )
+    target_link_libraries(ztail_tests PRIVATE gtest_main ztail_lib)
+
+    include(GoogleTest)
+    gtest_discover_tests(ztail_tests)
+endif()

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 3. **Configure the Project with CMake:**
 
    ```bash
-   cmake ..
+   cmake .. -DBUILD_TESTING=ON
    ```
 
 4. **Build the Project:**
@@ -63,13 +63,19 @@
 
 Unit tests are located in the `tests/` directory. To run them:
 
-1. **Navigate to the Build Directory:**
+1. **Ensure the project was configured with testing enabled:**
+
+   ```bash
+   cmake .. -DBUILD_TESTING=ON
+   ```
+
+2. **Navigate to the Build Directory:**
 
    ```bash
    cd build
    ```
 
-2. **Execute the Tests:**
+3. **Execute the Tests:**
 
    ```bash
    ctest --output-on-failure

--- a/src/compressor_zlib.cpp
+++ b/src/compressor_zlib.cpp
@@ -1,8 +1,20 @@
 #include "compressor_zlib.h"
+#include <fstream>
 
 CompressorZlib::CompressorZlib(const std::string& filename)
     : gz(nullptr), eof(false)
 {
+    std::ifstream check(filename, std::ios::binary);
+    if (!check) {
+        throw std::runtime_error("Failed to open gz/bgz file: " + filename);
+    }
+
+    unsigned char header[2];
+    check.read(reinterpret_cast<char*>(header), 2);
+    if (check.gcount() != 2 || header[0] != 0x1f || header[1] != 0x8b) {
+        throw std::runtime_error("Invalid gz/bgz file: " + filename);
+    }
+
     gz = gzopen(filename.c_str(), "rb");
     if (!gz) {
         throw std::runtime_error("Failed to open gz/bgz file: " + filename);

--- a/tests/test_compressor_zlib.cpp
+++ b/tests/test_compressor_zlib.cpp
@@ -38,10 +38,6 @@ TEST(CompressorZlibTest, DecompressInvalidFile) {
 
     EXPECT_THROW({
         CompressorZlib compressor(filename);
-        std::vector<char> buffer(1024);
-        size_t bytesDecompressed = 0;
-
-        compressor.decompress(buffer, bytesDecompressed);
     }, std::runtime_error);
 
     remove(filename.c_str());


### PR DESCRIPTION
## Summary
- add CTest and GoogleTest integration
- build a `ztail_lib` library and test executable
- check gzip header in `CompressorZlib` constructor
- adjust failing test and workflow to enable tests
- document running tests in README

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_684e26097d0c832a86cf132839941860