### PR TITLE
Add bzip2 compression support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,14 @@ else()
     message(FATAL_ERROR "ZLIB not found!")
 endif()
 
+# Find BZip2
+find_package(BZip2 REQUIRED)
+if(BZIP2_FOUND)
+    message(STATUS "BZip2 found: ${BZIP2_INCLUDE_DIRS}")
+else()
+    message(FATAL_ERROR "BZip2 not found!")
+endif()
+
 # Find LibZip
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBZIP REQUIRED libzip)
@@ -57,6 +65,7 @@ endif()
 include_directories(
     ${ZLIB_INCLUDE_DIRS}
     ${LIBZIP_INCLUDE_DIRS}
+    ${BZIP2_INCLUDE_DIRS}
     src
 )
 
@@ -68,6 +77,7 @@ set(ZTAIL_LIB_SOURCES
     src/circular_buffer.cpp
     src/cli.cpp
     src/compressor_zlib.cpp
+    src/compressor_bzip2.cpp
     src/compressor_zip.cpp
     src/parser.cpp
 )
@@ -77,6 +87,7 @@ add_library(ztail_lib ${ZTAIL_LIB_SOURCES})
 target_link_libraries(ztail_lib
     PUBLIC
         ${ZLIB_LIBRARIES}
+        ${BZIP2_LIBRARIES}
         ${LIBZIP_LIBRARIES}
 )
 target_include_directories(ztail_lib PUBLIC src)
@@ -100,6 +111,7 @@ if(BUILD_TESTING)
     add_executable(ztail_tests
         tests/test_circular_buffer.cpp
         tests/test_compressor_zlib.cpp
+        tests/test_compressor_bzip2.cpp
         tests/test_compressor_zip.cpp
         tests/test_parser.cpp
     )

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ztail
 
-**ztail** is an efficient command-line tool to display the last N lines of compressed `.gz` and `.zip` files. Designed for high performance, **ztail** is ideal for working with large compressed text files.
+**ztail** is an efficient command-line tool to display the last N lines of compressed `.gz`, `.bz2`, and `.zip` files. Designed for high performance, **ztail** is ideal for working with large compressed text files.
 
 ## 🛠️ **Features**
 
-- **Supports `.gz` and `.zip` Files:** Decompresses and processes these compressed file formats efficiently.
+- **Supports `.gz`, `.bz2`, and `.zip` Files:** Decompresses and processes these compressed file formats efficiently.
 - **High Performance:** Optimized for large files, avoiding unnecessary full decompressions.
 - **Intuitive Command-Line Interface:** Simple usage with flexible options.
 
@@ -15,6 +15,7 @@
 - **C++17** or higher.
 - **CMake** (version 3.10 or higher).
 - **zlib Library:** For decompressing `.gz` and `.bgz` files.
+- **bzip2 Library:** For handling `.bz2` files.
 - **libzip Library:** For handling `.zip` files.
 
 ### 🔧 **Build Steps**
@@ -49,15 +50,16 @@
 
 ## 🚀 **Usage**
 
-### **Display the Last N Lines of a `.gz` or `.zip` File**
+### **Display the Last N Lines of a `.gz`, `.bz2`, or `.zip` File**
 
 ```bash
 ./ztail -n 2 file.gz
+./ztail -n 2 file.bz2
 ./ztail -n 2 file.zip
 ```
 
 - **`-n N`**: Display the last N lines (default = 10).
-- **`file.gz` or `file.zip`**: Name of the compressed file.
+- **`file.gz`, `file.bz2`, or `file.zip`**: Name of the compressed file.
 
 ## 🧪 **Tests**
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -5,7 +5,7 @@
 
 void CLI::usage(const char* progName) {
     std::cerr
-        << "Usage: " << progName << " [-n N] <file.gz | file.bgz | file.zip>\n"
+        << "Usage: " << progName << " [-n N] <file.gz | file.bgz | file.bz2 | file.zip>\n"
         << "       " << progName << " [-n N]\n"
         << "  -n N : print the last N lines (default = 10)\n"
         << "  If no file is provided, the program reads from stdin.\n";

--- a/src/compressor_bzip2.cpp
+++ b/src/compressor_bzip2.cpp
@@ -1,0 +1,56 @@
+#include "compressor_bzip2.h"
+#include <fstream>
+
+CompressorBzip2::CompressorBzip2(const std::string& filename)
+    : file(nullptr), bz(nullptr), bzerror(BZ_OK), eof(false)
+{
+    std::ifstream check(filename, std::ios::binary);
+    if (!check) {
+        throw std::runtime_error("Failed to open bz2 file: " + filename);
+    }
+
+    file = fopen(filename.c_str(), "rb");
+    if (!file) {
+        throw std::runtime_error("Failed to open bz2 file: " + filename);
+    }
+
+    bz = BZ2_bzReadOpen(&bzerror, file, 0, 0, nullptr, 0);
+    if (!bz || bzerror != BZ_OK) {
+        if (bz) {
+            BZ2_bzReadClose(&bzerror, bz);
+        }
+        fclose(file);
+        throw std::runtime_error("Failed to initialize bz2 decompression: " + filename);
+    }
+}
+
+CompressorBzip2::~CompressorBzip2() {
+    if (bz) {
+        BZ2_bzReadClose(&bzerror, bz);
+    }
+    if (file) {
+        fclose(file);
+    }
+}
+
+bool CompressorBzip2::decompress(std::vector<char>& outBuffer, size_t& bytesDecompressed) {
+    if (eof) {
+        bytesDecompressed = 0;
+        return false;
+    }
+
+    int nread = BZ2_bzRead(&bzerror, bz, outBuffer.data(), static_cast<int>(outBuffer.size()));
+    if (bzerror != BZ_OK && bzerror != BZ_STREAM_END) {
+        throw std::runtime_error("Error while decompressing bz2 file");
+    }
+    if (bzerror == BZ_STREAM_END) {
+        eof = true;
+    }
+    if (nread < 0) {
+        bytesDecompressed = 0;
+        return false;
+    }
+    bytesDecompressed = static_cast<size_t>(nread);
+    return bytesDecompressed > 0;
+}
+

--- a/src/compressor_bzip2.h
+++ b/src/compressor_bzip2.h
@@ -1,0 +1,26 @@
+#ifndef COMPRESSOR_BZIP2_H
+#define COMPRESSOR_BZIP2_H
+
+#include <bzlib.h>
+#include <string>
+#include <vector>
+#include <stdexcept>
+#include <cstdio>
+
+class CompressorBzip2 {
+public:
+    explicit CompressorBzip2(const std::string& filename);
+    ~CompressorBzip2();
+
+    // Reads the next chunk of decompressed data
+    // Returns true while data is available, false on EOF
+    bool decompress(std::vector<char>& outBuffer, size_t& bytesDecompressed);
+
+private:
+    FILE* file;
+    BZFILE* bz;
+    int bzerror;
+    bool eof;
+};
+
+#endif // COMPRESSOR_BZIP2_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include "parser.h"
 #include "compressor_zlib.h"
 #include "compressor_zip.h"
+#include "compressor_bzip2.h"
 
 #include <iostream>
 #include <stdexcept>
@@ -26,6 +27,7 @@ int main(int argc, char* argv[]) {
 
             bool isGz  = false;
             bool isBgz = false;
+            bool isBz2 = false;
             bool isZip = false;
 
             // Check the file extension
@@ -41,9 +43,13 @@ int main(int argc, char* argv[]) {
                      (filename.compare(filename.size() - 4, 4, ".zip") == 0)) {
                 isZip = true;
             }
+            else if (filename.size() >= 4 &&
+                     (filename.compare(filename.size() - 4, 4, ".bz2") == 0)) {
+                isBz2 = true;
+            }
             else {
                 std::cerr << "Unrecognized extension in \"" << filename
-                          << "\". Only .gz, .bgz, and .zip are supported.\n";
+                          << "\". Only .gz, .bgz, .bz2, and .zip are supported.\n";
                 return EXIT_FAILURE;
             }
 
@@ -54,6 +60,17 @@ int main(int argc, char* argv[]) {
             if (isGz || isBgz) {
                 // Use zlib
                 CompressorZlib compressor(filename);
+
+                while (compressor.decompress(decompressedBuffer, bytesDecompressed)) {
+                    if (bytesDecompressed > 0) {
+                        parser.parse(decompressedBuffer.data(), bytesDecompressed);
+                    }
+                }
+                parser.finalize();
+            }
+            else if (isBz2) {
+                // Use bzip2
+                CompressorBzip2 compressor(filename);
 
                 while (compressor.decompress(decompressedBuffer, bytesDecompressed)) {
                     if (bytesDecompressed > 0) {

--- a/tests/test_compressor_bzip2.cpp
+++ b/tests/test_compressor_bzip2.cpp
@@ -1,0 +1,55 @@
+#include <gtest/gtest.h>
+#include "compressor_bzip2.h"
+#include <bzlib.h>
+#include <cstdio>
+
+// Helper function to create a temporary bz2 file for testing
+void create_bz2_file(const std::string& filename, const std::string& content) {
+    FILE* f = fopen(filename.c_str(), "wb");
+    ASSERT_NE(f, nullptr) << "Failed to create bz2 file";
+    int bzerror = BZ_OK;
+    BZFILE* bf = BZ2_bzWriteOpen(&bzerror, f, 9, 0, 0);
+    ASSERT_EQ(bzerror, BZ_OK) << "Failed to open bz2 writer";
+    BZ2_bzWrite(&bzerror, bf, const_cast<char*>(content.data()), content.size());
+    ASSERT_EQ(bzerror, BZ_OK) << "Failed to write bz2 data";
+    BZ2_bzWriteClose(&bzerror, bf, 0, nullptr, nullptr);
+    fclose(f);
+}
+
+TEST(CompressorBzip2Test, DecompressValidFile) {
+    const std::string filename = "test.bz2";
+    const std::string content = "Line A\nLine B\nLine C\n";
+
+    create_bz2_file(filename, content);
+
+    CompressorBzip2 compressor(filename);
+    std::vector<char> buffer(1024);
+    size_t bytesDecompressed = 0;
+
+    std::string decompressed;
+    while (compressor.decompress(buffer, bytesDecompressed)) {
+        decompressed.append(buffer.data(), bytesDecompressed);
+    }
+
+    EXPECT_EQ(decompressed, content);
+    remove(filename.c_str());
+}
+
+TEST(CompressorBzip2Test, DecompressInvalidFile) {
+    const std::string filename = "test_invalid.bz2";
+
+    FILE* f = fopen(filename.c_str(), "wb");
+    fprintf(f, "Invalid data");
+    fclose(f);
+
+    EXPECT_THROW({
+        CompressorBzip2 compressor(filename);
+        std::vector<char> buffer(1024);
+        size_t bytesDecompressed = 0;
+
+        compressor.decompress(buffer, bytesDecompressed);
+    }, std::runtime_error);
+
+    remove(filename.c_str());
+}
+


### PR DESCRIPTION
## Summary
- support `.bz2` archives by adding new compressor
- allow `.bz2` input in CLI and usage docs
- document `bzip2` requirement in README
- update CMake to link against BZip2
- extend unit tests for `.bz2` files

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_684e29089074832a8dcb4186768c2c48