### PR TITLE
Fix LTO flags gating in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,11 @@ endif()
 add_compile_options(
     -O3
     -march=native
-    -flto
     -pipe
 )
 
 if(ipo_supported)
+    add_compile_options(-flto)
     add_link_options(
         -flto
     )


### PR DESCRIPTION
## Summary
- add `-flto` to compile flags only when IPO is supported

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_684e2ddd54b0832a85de45a801a38ce0