### PR TITLE
Add xz compression support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,11 +54,17 @@ endif()
 # Find LibZip
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBZIP REQUIRED libzip)
+pkg_check_modules(LIBLZMA REQUIRED liblzma)
 
 if(LIBZIP_FOUND)
     message(STATUS "LibZip found: ${LIBZIP_INCLUDE_DIRS}")
 else()
     message(FATAL_ERROR "LibZip not found!")
+endif()
+if(LIBLZMA_FOUND)
+    message(STATUS "LibLZMA found: ${LIBLZMA_INCLUDE_DIRS}")
+else()
+    message(FATAL_ERROR "LibLZMA not found!")
 endif()
 
 # Include Directories
@@ -66,6 +72,7 @@ include_directories(
     ${ZLIB_INCLUDE_DIRS}
     ${LIBZIP_INCLUDE_DIRS}
     ${BZIP2_INCLUDE_DIRS}
+    ${LIBLZMA_INCLUDE_DIRS}
     src
 )
 
@@ -78,6 +85,7 @@ set(ZTAIL_LIB_SOURCES
     src/cli.cpp
     src/compressor_zlib.cpp
     src/compressor_bzip2.cpp
+    src/compressor_xz.cpp
     src/compressor_zip.cpp
     src/parser.cpp
 )
@@ -88,6 +96,7 @@ target_link_libraries(ztail_lib
     PUBLIC
         ${ZLIB_LIBRARIES}
         ${BZIP2_LIBRARIES}
+        ${LIBLZMA_LIBRARIES}
         ${LIBZIP_LIBRARIES}
 )
 target_include_directories(ztail_lib PUBLIC src)
@@ -112,6 +121,7 @@ if(BUILD_TESTING)
         tests/test_circular_buffer.cpp
         tests/test_compressor_zlib.cpp
         tests/test_compressor_bzip2.cpp
+        tests/test_compressor_xz.cpp
         tests/test_compressor_zip.cpp
         tests/test_parser.cpp
     )

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ztail
 
-**ztail** is an efficient command-line tool to display the last N lines of compressed `.gz`, `.bz2`, and `.zip` files. Designed for high performance, **ztail** is ideal for working with large compressed text files.
+**ztail** is an efficient command-line tool to display the last N lines of compressed `.gz`, `.bz2`, `.xz`, and `.zip` files. Designed for high performance, **ztail** is ideal for working with large compressed text files.
 
 ## 🛠️ **Features**
 
-- **Supports `.gz`, `.bz2`, and `.zip` Files:** Decompresses and processes these compressed file formats efficiently.
+- **Supports `.gz`, `.bz2`, `.xz`, and `.zip` Files:** Decompresses and processes these compressed file formats efficiently.
 - **High Performance:** Optimized for large files, avoiding unnecessary full decompressions.
 - **Intuitive Command-Line Interface:** Simple usage with flexible options.
 
@@ -16,12 +16,13 @@
 - **CMake** (version 3.10 or higher).
 - **zlib Library:** For decompressing `.gz` and `.bgz` files.
 - **bzip2 Library:** For handling `.bz2` files.
+- **liblzma Library:** For handling `.xz` files.
 - **libzip Library:** For handling `.zip` files.
 
 On Ubuntu/Debian the required packages can typically be installed with:
 
 ```bash
-sudo apt install zlib1g-dev libbz2-dev libzip-dev
+sudo apt install zlib1g-dev libbz2-dev liblzma-dev libzip-dev
 ```
 
 Library names may vary on other operating systems.
@@ -58,16 +59,17 @@ Library names may vary on other operating systems.
 
 ## 🚀 **Usage**
 
-### **Display the Last N Lines of a `.gz`, `.bz2`, or `.zip` File**
+### **Display the Last N Lines of a `.gz`, `.bz2`, `.xz`, or `.zip` File**
 
 ```bash
 ./ztail -n 2 file.gz
 ./ztail -n 2 file.bz2
+./ztail -n 2 file.xz
 ./ztail -n 2 file.zip
 ```
 
 - **`-n N`**: Display the last N lines (default = 10).
-- **`file.gz`, `file.bz2`, or `file.zip`**: Name of the compressed file.
+- **`file.gz`, `file.bz2`, `file.xz`, or `file.zip`**: Name of the compressed file.
 
 ## 🧪 **Tests**
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -7,7 +7,7 @@
 
 void CLI::usage(const char* progName) {
     std::cerr
-        << "Usage: " << progName << " [-n N] <file.gz | file.bgz | file.bz2 | file.zip>\n"
+        << "Usage: " << progName << " [-n N] <file.gz | file.bgz | file.bz2 | file.xz | file.zip>\n"
         << "       " << progName << " [-n N]\n"
         << "  -n N : print the last N lines (default = 10)\n"
         << "  If no file is provided, the program reads from stdin.\n";

--- a/src/compressor_xz.cpp
+++ b/src/compressor_xz.cpp
@@ -1,0 +1,72 @@
+#include "compressor_xz.h"
+#include <fstream>
+
+CompressorXz::CompressorXz(const std::string& filename)
+    : file(nullptr), strm(LZMA_STREAM_INIT), eof(false), inBuffer(1 << 15)
+{
+    std::ifstream check(filename, std::ios::binary);
+    if (!check) {
+        throw std::runtime_error("Failed to open xz file: " + filename);
+    }
+
+    file = fopen(filename.c_str(), "rb");
+    if (!file) {
+        throw std::runtime_error("Failed to open xz file: " + filename);
+    }
+
+    lzma_ret ret = lzma_stream_decoder(&strm, UINT64_MAX, 0);
+    if (ret != LZMA_OK) {
+        fclose(file);
+        throw std::runtime_error("Failed to initialize xz decoder");
+    }
+}
+
+CompressorXz::~CompressorXz() {
+    lzma_end(&strm);
+    if (file) {
+        fclose(file);
+    }
+}
+
+bool CompressorXz::decompress(std::vector<char>& outBuffer, size_t& bytesDecompressed) {
+    if (eof) {
+        bytesDecompressed = 0;
+        return false;
+    }
+
+    strm.next_out = reinterpret_cast<uint8_t*>(outBuffer.data());
+    strm.avail_out = outBuffer.size();
+
+    bytesDecompressed = 0;
+
+    while (strm.avail_out > 0) {
+        if (strm.avail_in == 0 && !eof) {
+            size_t nread = fread(inBuffer.data(), 1, inBuffer.size(), file);
+            if (nread == 0) {
+                eof = true;
+            }
+            strm.next_in = inBuffer.data();
+            strm.avail_in = nread;
+        }
+
+        lzma_ret ret = lzma_code(&strm, eof && strm.avail_in == 0 ? LZMA_FINISH : LZMA_RUN);
+        if (ret == LZMA_STREAM_END) {
+            eof = true;
+            break;
+        }
+        if (ret != LZMA_OK && ret != LZMA_BUF_ERROR) {
+            throw std::runtime_error("Error while decompressing xz file");
+        }
+        if (ret == LZMA_BUF_ERROR && strm.avail_in == 0) {
+            // Need more input
+            continue;
+        }
+        if (ret == LZMA_BUF_ERROR) {
+            break;
+        }
+    }
+
+    bytesDecompressed = outBuffer.size() - strm.avail_out;
+    return bytesDecompressed > 0;
+}
+

--- a/src/compressor_xz.h
+++ b/src/compressor_xz.h
@@ -1,0 +1,26 @@
+#ifndef COMPRESSOR_XZ_H
+#define COMPRESSOR_XZ_H
+
+#include <lzma.h>
+#include <string>
+#include <vector>
+#include <stdexcept>
+#include <cstdio>
+
+class CompressorXz {
+public:
+    explicit CompressorXz(const std::string& filename);
+    ~CompressorXz();
+
+    // Reads the next chunk of decompressed data
+    // Returns true while data is available, false on EOF
+    bool decompress(std::vector<char>& outBuffer, size_t& bytesDecompressed);
+
+private:
+    FILE* file;
+    lzma_stream strm;
+    bool eof;
+    std::vector<uint8_t> inBuffer;
+};
+
+#endif // COMPRESSOR_XZ_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "compressor_zlib.h"
 #include "compressor_zip.h"
 #include "compressor_bzip2.h"
+#include "compressor_xz.h"
 
 #include <iostream>
 #include <stdexcept>
@@ -29,6 +30,7 @@ int main(int argc, char* argv[]) {
             bool isBgz = false;
             bool isBz2 = false;
             bool isZip = false;
+            bool isXz  = false;
 
             // Check the file extension
             if (filename.size() >= 3 &&
@@ -47,9 +49,13 @@ int main(int argc, char* argv[]) {
                      (filename.compare(filename.size() - 4, 4, ".bz2") == 0)) {
                 isBz2 = true;
             }
+            else if (filename.size() >= 3 &&
+                     (filename.compare(filename.size() - 3, 3, ".xz") == 0)) {
+                isXz = true;
+            }
             else {
                 std::cerr << "Unrecognized extension in \"" << filename
-                          << "\". Only .gz, .bgz, .bz2, and .zip are supported.\n";
+                          << "\". Only .gz, .bgz, .bz2, .xz, and .zip are supported.\n";
                 return EXIT_FAILURE;
             }
 
@@ -71,6 +77,17 @@ int main(int argc, char* argv[]) {
             else if (isBz2) {
                 // Use bzip2
                 CompressorBzip2 compressor(filename);
+
+                while (compressor.decompress(decompressedBuffer, bytesDecompressed)) {
+                    if (bytesDecompressed > 0) {
+                        parser.parse(decompressedBuffer.data(), bytesDecompressed);
+                    }
+                }
+                parser.finalize();
+            }
+            else if (isXz) {
+                // Use liblzma
+                CompressorXz compressor(filename);
 
                 while (compressor.decompress(decompressedBuffer, bytesDecompressed)) {
                     if (bytesDecompressed > 0) {

--- a/tests/test_compressor_xz.cpp
+++ b/tests/test_compressor_xz.cpp
@@ -1,0 +1,54 @@
+#include <gtest/gtest.h>
+#include "compressor_xz.h"
+#include <fstream>
+#include <lzma.h>
+
+// Helper function to create a temporary xz file for testing
+void create_xz_file(const std::string& filename, const std::string& content) {
+    size_t out_pos = 0;
+    size_t out_size = lzma_stream_buffer_bound(content.size());
+    std::vector<uint8_t> out(out_size);
+    lzma_ret ret = lzma_easy_buffer_encode(6, LZMA_CHECK_CRC64, nullptr,
+                                           reinterpret_cast<const uint8_t*>(content.data()),
+                                           content.size(), out.data(), &out_pos, out_size);
+    ASSERT_EQ(ret, LZMA_OK) << "Failed to encode xz";
+    std::ofstream ofs(filename, std::ios::binary);
+    ofs.write(reinterpret_cast<char*>(out.data()), out_pos);
+}
+
+TEST(CompressorXzTest, DecompressValidFile) {
+    const std::string filename = "test.xz";
+    const std::string content = "Line A\nLine B\nLine C\n";
+
+    create_xz_file(filename, content);
+
+    CompressorXz compressor(filename);
+    std::vector<char> buffer(1024);
+    size_t bytesDecompressed = 0;
+
+    std::string decompressed;
+    while (compressor.decompress(buffer, bytesDecompressed)) {
+        decompressed.append(buffer.data(), bytesDecompressed);
+    }
+
+    EXPECT_EQ(decompressed, content);
+    remove(filename.c_str());
+}
+
+TEST(CompressorXzTest, DecompressInvalidFile) {
+    const std::string filename = "test_invalid.xz";
+
+    std::ofstream ofs(filename);
+    ofs << "Invalid data";
+    ofs.close();
+
+    EXPECT_THROW({
+        CompressorXz compressor(filename);
+        std::vector<char> buffer(1024);
+        size_t bytesDecompressed = 0;
+        compressor.decompress(buffer, bytesDecompressed);
+    }, std::runtime_error);
+
+    remove(filename.c_str());
+}
+


### PR DESCRIPTION
## Summary
- add `compressor_xz` implementation using liblzma
- detect and handle `.xz` files in `main`
- search for LibLZMA in CMake and link against it
- update CLI usage and README with `.xz` support
- add unit tests for `.xz` decompression

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684e2f093984832ab9cf57dd53c58f03