### PR TITLE
Add magic byte compression detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,8 +114,11 @@ if(BUILD_TESTING)
         tests/test_compressor_bzip2.cpp
         tests/test_compressor_zip.cpp
         tests/test_parser.cpp
+        tests/test_detection.cpp
+        src/main.cpp
     )
     target_link_libraries(ztail_tests PRIVATE gtest_main ztail_lib)
+    target_compile_definitions(ztail_tests PRIVATE ZTAIL_NO_MAIN)
 
     include(GoogleTest)
     gtest_discover_tests(ztail_tests)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## 🛠️ **Features**
 
 - **Supports `.gz`, `.bz2`, and `.zip` Files:** Decompresses and processes these compressed file formats efficiently.
+- **Automatic Detection:** Compression type is identified from file contents even when the extension is missing or wrong.
 - **High Performance:** Optimized for large files, avoiding unnecessary full decompressions.
 - **Intuitive Command-Line Interface:** Simple usage with flexible options.
 
@@ -67,7 +68,7 @@ Library names may vary on other operating systems.
 ```
 
 - **`-n N`**: Display the last N lines (default = 10).
-- **`file.gz`, `file.bz2`, or `file.zip`**: Name of the compressed file.
+- **`file.gz`, `file.bz2`, or `file.zip`**: Name of the compressed file. The extension may be omitted as the compression type is detected automatically.
 
 ## 🧪 **Tests**
 

--- a/src/compression_type.h
+++ b/src/compression_type.h
@@ -1,0 +1,16 @@
+#ifndef COMPRESSION_TYPE_H
+#define COMPRESSION_TYPE_H
+
+#include <string>
+
+enum class CompressionType {
+    NONE,
+    GZIP,
+    BZIP2,
+    XZ,
+    ZIP
+};
+
+CompressionType detectCompressionType(const std::string& filename);
+
+#endif // COMPRESSION_TYPE_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,15 +4,48 @@
 #include "compressor_zlib.h"
 #include "compressor_zip.h"
 #include "compressor_bzip2.h"
+#include "compression_type.h"
 
 #include <iostream>
 #include <stdexcept>
 #include <cstdio>      // for fread
 #include <vector>
 #include <cstdlib>     // for EXIT_SUCCESS/EXIT_FAILURE
+#include <fstream>
+
+// Detect the compression type by inspecting the file's magic bytes
+CompressionType detectCompressionType(const std::string& filename) {
+    std::ifstream file(filename, std::ios::binary);
+    if (!file) {
+        return CompressionType::NONE;
+    }
+
+    unsigned char bytes[6] = {0};
+    file.read(reinterpret_cast<char*>(bytes), sizeof(bytes));
+    std::size_t read = static_cast<std::size_t>(file.gcount());
+
+    if (read >= 2 && bytes[0] == 0x1f && bytes[1] == 0x8b) {
+        return CompressionType::GZIP;      // gzip or bgz
+    }
+    if (read >= 3 && bytes[0] == 'B' && bytes[1] == 'Z' && bytes[2] == 'h') {
+        return CompressionType::BZIP2;     // bzip2
+    }
+    if (read >= 6 && bytes[0] == 0xFD && bytes[1] == 0x37 && bytes[2] == 0x7A &&
+        bytes[3] == 0x58 && bytes[4] == 0x5A && bytes[5] == 0x00) {
+        return CompressionType::XZ;        // xz
+    }
+    if (read >= 4 && bytes[0] == 0x50 && bytes[1] == 0x4B &&
+        (bytes[2] == 0x03 || bytes[2] == 0x05 || bytes[2] == 0x07) &&
+        (bytes[3] == 0x04 || bytes[3] == 0x06 || bytes[3] == 0x08)) {
+        return CompressionType::ZIP;       // zip
+    }
+
+    return CompressionType::NONE;
+}
 
 static const size_t READ_BUFFER_SIZE = 1 << 20; // 1MB
 
+#ifndef ZTAIL_NO_MAIN
 int main(int argc, char* argv[]) {
     // Parse command-line arguments
     CLIOptions options = CLI::parse(argc, argv);
@@ -29,27 +62,50 @@ int main(int argc, char* argv[]) {
             bool isBgz = false;
             bool isBz2 = false;
             bool isZip = false;
+            bool isXz  = false;
 
-            // Check the file extension
-            if (filename.size() >= 3 &&
-                (filename.compare(filename.size() - 3, 3, ".gz") == 0)) {
+            // First attempt to detect by magic bytes
+            CompressionType ctype = detectCompressionType(filename);
+            if (ctype == CompressionType::GZIP) {
                 isGz = true;
             }
-            else if (filename.size() >= 4 &&
-                     (filename.compare(filename.size() - 4, 4, ".bgz") == 0)) {
-                isBgz = true;
-            }
-            else if (filename.size() >= 4 &&
-                     (filename.compare(filename.size() - 4, 4, ".zip") == 0)) {
-                isZip = true;
-            }
-            else if (filename.size() >= 4 &&
-                     (filename.compare(filename.size() - 4, 4, ".bz2") == 0)) {
+            else if (ctype == CompressionType::BZIP2) {
                 isBz2 = true;
             }
-            else {
-                std::cerr << "Unrecognized extension in \"" << filename
-                          << "\". Only .gz, .bgz, .bz2, and .zip are supported.\n";
+            else if (ctype == CompressionType::ZIP) {
+                isZip = true;
+            }
+            else if (ctype == CompressionType::XZ) {
+                isXz = true;
+            }
+
+            // Fallback to extension check if detection failed
+            if (ctype == CompressionType::NONE) {
+                if (filename.size() >= 3 &&
+                    (filename.compare(filename.size() - 3, 3, ".gz") == 0)) {
+                    isGz = true;
+                }
+                else if (filename.size() >= 4 &&
+                         (filename.compare(filename.size() - 4, 4, ".bgz") == 0)) {
+                    isBgz = true;
+                }
+                else if (filename.size() >= 4 &&
+                         (filename.compare(filename.size() - 4, 4, ".zip") == 0)) {
+                    isZip = true;
+                }
+                else if (filename.size() >= 4 &&
+                         (filename.compare(filename.size() - 4, 4, ".bz2") == 0)) {
+                    isBz2 = true;
+                }
+                else {
+                    std::cerr << "Unrecognized extension in \"" << filename
+                              << "\". Only .gz, .bgz, .bz2, and .zip are supported.\n";
+                    return EXIT_FAILURE;
+                }
+            }
+
+            if (isXz) {
+                std::cerr << "Compression type xz is not supported: " << filename << "\n";
                 return EXIT_FAILURE;
             }
 
@@ -116,3 +172,4 @@ int main(int argc, char* argv[]) {
 
     return EXIT_SUCCESS;
 }
+#endif // ZTAIL_NO_MAIN

--- a/tests/test_detection.cpp
+++ b/tests/test_detection.cpp
@@ -1,0 +1,59 @@
+#include <gtest/gtest.h>
+#include "compression_type.h"
+#include <fstream>
+#include <cstdio>
+#include <zlib.h>
+#include <bzlib.h>
+#include <zip.h>
+
+static void create_gz(const std::string& fname, const std::string& data){
+    gzFile gz = gzopen(fname.c_str(), "wb");
+    ASSERT_TRUE(gz);
+    gzwrite(gz, data.data(), data.size());
+    gzclose(gz);
+}
+
+static void create_bz2(const std::string& fname, const std::string& data){
+    FILE* f = fopen(fname.c_str(), "wb");
+    ASSERT_TRUE(f);
+    int bzerror = BZ_OK;
+    BZFILE* bz = BZ2_bzWriteOpen(&bzerror, f, 9, 0, 0);
+    ASSERT_EQ(bzerror, BZ_OK);
+    BZ2_bzWrite(&bzerror, bz, const_cast<char*>(data.data()), data.size());
+    ASSERT_EQ(bzerror, BZ_OK);
+    BZ2_bzWriteClose(&bzerror, bz, 0, nullptr, nullptr);
+    fclose(f);
+}
+
+static void create_zip(const std::string& fname, const std::string& data){
+    int error = 0;
+    zip_t* za = zip_open(fname.c_str(), ZIP_CREATE | ZIP_TRUNCATE, &error);
+    ASSERT_NE(za, nullptr);
+    zip_source_t* zs = zip_source_buffer(za, data.c_str(), data.size(), 0);
+    ASSERT_NE(zs, nullptr);
+    int idx = zip_file_add(za, "file.txt", zs, ZIP_FL_OVERWRITE);
+    ASSERT_GE(idx, 0);
+    ASSERT_EQ(zip_close(za), 0);
+}
+
+TEST(CompressionDetection, GzipWrongExtension){
+    const std::string fname = "sample.txt";
+    create_gz(fname, "a\n");
+    EXPECT_EQ(detectCompressionType(fname), CompressionType::GZIP);
+    std::remove(fname.c_str());
+}
+
+TEST(CompressionDetection, Bzip2NoExtension){
+    const std::string fname = "sample";
+    create_bz2(fname, "b\n");
+    EXPECT_EQ(detectCompressionType(fname), CompressionType::BZIP2);
+    std::remove(fname.c_str());
+}
+
+TEST(CompressionDetection, ZipMisleadingExtension){
+    const std::string fname = "archive.gz";
+    create_zip(fname, "c\n");
+    EXPECT_EQ(detectCompressionType(fname), CompressionType::ZIP);
+    std::remove(fname.c_str());
+}
+


### PR DESCRIPTION
## Summary
- detect compression format by inspecting magic bytes
- fall back to extension check
- skip `main` symbol when building tests and add detection unit tests
- document automatic compression detection

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684e2f0e8c20832a96e893ed126d75e9