### PR TITLE
Implement detection refactor and performance features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ endif()
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBZIP REQUIRED libzip)
 pkg_check_modules(LIBLZMA REQUIRED liblzma)
+pkg_check_modules(LIBZSTD REQUIRED libzstd)
 
 if(LIBZIP_FOUND)
     message(STATUS "LibZip found: ${LIBZIP_INCLUDE_DIRS}")
@@ -66,6 +67,11 @@ if(LIBLZMA_FOUND)
 else()
     message(FATAL_ERROR "LibLZMA not found!")
 endif()
+if(LIBZSTD_FOUND)
+    message(STATUS "LibZSTD found: ${LIBZSTD_INCLUDE_DIRS}")
+else()
+    message(FATAL_ERROR "LibZSTD not found!")
+endif()
 
 # Include Directories
 include_directories(
@@ -73,6 +79,7 @@ include_directories(
     ${LIBZIP_INCLUDE_DIRS}
     ${BZIP2_INCLUDE_DIRS}
     ${LIBLZMA_INCLUDE_DIRS}
+    ${LIBZSTD_INCLUDE_DIRS}
     src
 )
 
@@ -87,6 +94,9 @@ set(ZTAIL_LIB_SOURCES
     src/compressor_bzip2.cpp
     src/compressor_xz.cpp
     src/compressor_zip.cpp
+    src/compressor_zstd.cpp
+    src/compression_type.cpp
+    src/tail_plain.cpp
     src/parser.cpp
 )
 
@@ -98,6 +108,7 @@ target_link_libraries(ztail_lib
         ${BZIP2_LIBRARIES}
         ${LIBLZMA_LIBRARIES}
         ${LIBZIP_LIBRARIES}
+        ${LIBZSTD_LIBRARIES}
 )
 target_include_directories(ztail_lib PUBLIC src)
 
@@ -123,6 +134,7 @@ if(BUILD_TESTING)
         tests/test_compressor_bzip2.cpp
         tests/test_compressor_xz.cpp
         tests/test_compressor_zip.cpp
+        tests/test_compressor_zstd.cpp
         tests/test_parser.cpp
         tests/test_detection.cpp
         src/main.cpp
@@ -133,3 +145,5 @@ if(BUILD_TESTING)
     include(GoogleTest)
     gtest_discover_tests(ztail_tests)
 endif()
+
+install(TARGETS ztail DESTINATION bin)

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -4,55 +4,47 @@
 #include <cstring>
 #include <cerrno>
 #include <limits>
+#include <stdexcept>
 
 void CLI::usage(const char* progName) {
     std::cerr
-        << "Usage: " << progName << " [-n N] <file.gz | file.bgz | file.bz2 | file.xz | file.zip>\n"
-        << "       " << progName << " [-n N]\n"
-        << "  -n N : print the last N lines (default = 10)\n"
-        << "  If no file is provided, the program reads from stdin.\n"
-        << "  Compression type is detected automatically.\n";
+        << "Usage: " << progName << " [options] <files...>\n"
+        << "  -n N        : print the last N lines (default = 10)\n"
+        << "  -e <name>   : entry name inside zip archive\n"
+        << "If no file is provided, the program reads from stdin.\n"
+        << "Compression type is detected automatically.\n";
 }
 
 CLIOptions CLI::parse(int argc, char* argv[]) {
     CLIOptions options;
-    int fileIndex = -1;
-
-    if (argc < 1) {
-        // Fallback usage call
-        usage("ztail_modular");
-        exit(EXIT_FAILURE);
-    }
 
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "-n") == 0) {
-            if (i + 1 < argc) {
-                char* end = nullptr;
-                errno = 0;
-                long val = std::strtol(argv[i + 1], &end, 10);
-                if (errno != 0 || end == argv[i + 1] || *end != '\0' ||
-                    val <= 0 || val > std::numeric_limits<int>::max()) {
-                    std::cerr << "Error: -n requires a positive integer.\n";
-                    usage(argv[0]);
-                    exit(EXIT_FAILURE);
-                }
-                options.n = static_cast<int>(val);
-                i++;
-            } else {
-                std::cerr << "Error: -n requires a number.\n";
-                usage(argv[0]);
-                exit(EXIT_FAILURE);
+            if (i + 1 >= argc) {
+                throw std::runtime_error("-n requires a number");
             }
-        } else {
-            // Only one file is supported; if a second one is provided, it's an error
-            if (fileIndex == -1) {
-                fileIndex = i;
-                options.filename = argv[i];
-            } else {
-                std::cerr << "Error: multiple files provided. Only one is supported.\n";
-                usage(argv[0]);
-                exit(EXIT_FAILURE);
+            char* end = nullptr;
+            errno = 0;
+            long val = std::strtol(argv[i + 1], &end, 10);
+            if (errno != 0 || end == argv[i + 1] || *end != '\0' ||
+                val <= 0 || val > std::numeric_limits<int>::max()) {
+                throw std::runtime_error("-n requires a positive integer");
             }
+            options.n = static_cast<int>(val);
+            ++i;
+        }
+        else if (std::strcmp(argv[i], "-e") == 0) {
+            if (i + 1 >= argc) {
+                throw std::runtime_error("-e requires an entry name");
+            }
+            options.zipEntry = argv[i + 1];
+            ++i;
+        }
+        else if (argv[i][0] == '-') {
+            throw std::runtime_error(std::string("Unknown option: ") + argv[i]);
+        }
+        else {
+            options.filenames.push_back(argv[i]);
         }
     }
 

--- a/src/cli.h
+++ b/src/cli.h
@@ -2,10 +2,12 @@
 #define CLI_H
 
 #include <string>
+#include <vector>
 
 struct CLIOptions {
     int n = 10;             // Number of lines to print (default = 10)
-    std::string filename;   // Name of the file (empty if reading from stdin)
+    std::vector<std::string> filenames;   // Names of files to process
+    std::string zipEntry;   // Optional entry name for zip files
 };
 
 class CLI {

--- a/src/compression_type.cpp
+++ b/src/compression_type.cpp
@@ -1,0 +1,54 @@
+#include "compression_type.h"
+#include <fstream>
+
+CompressionType detectCompressionType(const std::string& filename) {
+    std::ifstream file(filename, std::ios::binary);
+    if (!file) {
+        return CompressionType::NONE;
+    }
+
+    unsigned char bytes[6] = {0};
+    file.read(reinterpret_cast<char*>(bytes), sizeof(bytes));
+    std::size_t read = static_cast<std::size_t>(file.gcount());
+
+    if (read >= 4 && bytes[0] == 0x28 && bytes[1] == 0xB5 && bytes[2] == 0x2F && bytes[3] == 0xFD) {
+        return CompressionType::ZSTD;
+    }
+    if (read >= 2 && bytes[0] == 0x1f && bytes[1] == 0x8b) {
+        return CompressionType::GZIP;      // gzip or bgz
+    }
+    if (read >= 3 && bytes[0] == 'B' && bytes[1] == 'Z' && bytes[2] == 'h') {
+        return CompressionType::BZIP2;     // bzip2
+    }
+    if (read >= 6 && bytes[0] == 0xFD && bytes[1] == 0x37 && bytes[2] == 0x7A &&
+        bytes[3] == 0x58 && bytes[4] == 0x5A && bytes[5] == 0x00) {
+        return CompressionType::XZ;        // xz
+    }
+    if (read >= 4 && bytes[0] == 0x50 && bytes[1] == 0x4B &&
+        (bytes[2] == 0x03 || bytes[2] == 0x05 || bytes[2] == 0x07) &&
+        (bytes[3] == 0x04 || bytes[3] == 0x06 || bytes[3] == 0x08)) {
+        return CompressionType::ZIP;       // zip
+    }
+
+    // Fallback based on file extension
+    if (filename.size() >= 4 && filename.compare(filename.size() - 4, 4, ".zst") == 0) {
+        return CompressionType::ZSTD;
+    }
+    if (filename.size() >= 3 && filename.compare(filename.size() - 3, 3, ".gz") == 0) {
+        return CompressionType::GZIP;
+    }
+    if (filename.size() >= 4 && filename.compare(filename.size() - 4, 4, ".bgz") == 0) {
+        return CompressionType::GZIP;
+    }
+    if (filename.size() >= 4 && filename.compare(filename.size() - 4, 4, ".bz2") == 0) {
+        return CompressionType::BZIP2;
+    }
+    if (filename.size() >= 3 && filename.compare(filename.size() - 3, 3, ".xz") == 0) {
+        return CompressionType::XZ;
+    }
+    if (filename.size() >= 4 && filename.compare(filename.size() - 4, 4, ".zip") == 0) {
+        return CompressionType::ZIP;
+    }
+
+    return CompressionType::NONE;
+}

--- a/src/compression_type.h
+++ b/src/compression_type.h
@@ -8,10 +8,11 @@ enum class CompressionType {
     GZIP,
     BZIP2,
     XZ,
-    ZIP
+    ZIP,
+    ZSTD
 };
 
 CompressionType detectCompressionType(const std::string& filename);
-CompressionType detect_type(const std::string& filename);
+
 
 #endif // COMPRESSION_TYPE_H

--- a/src/compressor_zip.cpp
+++ b/src/compressor_zip.cpp
@@ -1,7 +1,7 @@
 #include "compressor_zip.h"
 
-CompressorZip::CompressorZip(const std::string& filename)
-    : za(nullptr), zf(nullptr), eof(false)
+CompressorZip::CompressorZip(const std::string& filename, const std::string& entryName)
+    : za(nullptr), zf(nullptr), entry(entryName), eof(false)
 {
     int zipError = 0;
     za = zip_open(filename.c_str(), ZIP_RDONLY, &zipError);
@@ -15,11 +15,18 @@ CompressorZip::CompressorZip(const std::string& filename)
         throw std::runtime_error("Empty zip file: " + filename);
     }
 
-    // We only open the first file in the zip archive
-    zf = zip_fopen_index(za, 0, 0);
-    if (!zf) {
-        zip_close(za);
-        throw std::runtime_error("Failed to open the first file in zip: " + filename);
+    if (!entry.empty()) {
+        zf = zip_fopen(za, entry.c_str(), 0);
+        if (!zf) {
+            zip_close(za);
+            throw std::runtime_error("Failed to open entry " + entry + " in zip: " + filename);
+        }
+    } else {
+        zf = zip_fopen_index(za, 0, 0);
+        if (!zf) {
+            zip_close(za);
+            throw std::runtime_error("Failed to open the first file in zip: " + filename);
+        }
     }
 }
 

--- a/src/compressor_zip.h
+++ b/src/compressor_zip.h
@@ -8,7 +8,7 @@
 
 class CompressorZip {
 public:
-    explicit CompressorZip(const std::string& filename);
+    explicit CompressorZip(const std::string& filename, const std::string& entry = "");
     ~CompressorZip();
 
     // Reads the next chunk of decompressed data
@@ -18,6 +18,7 @@ public:
 private:
     zip_t* za;
     zip_file_t* zf;
+    std::string entry;
     bool eof;
 };
 

--- a/src/compressor_zstd.cpp
+++ b/src/compressor_zstd.cpp
@@ -1,0 +1,64 @@
+#include "compressor_zstd.h"
+#include <cstdio>
+#include <cstring>
+
+CompressorZstd::CompressorZstd(const std::string& filename)
+    : file(nullptr), stream(nullptr), inBuffer(ZSTD_DStreamInSize()), eof(false)
+{
+    file = fopen(filename.c_str(), "rb");
+    if (!file) {
+        throw std::runtime_error("Failed to open zst file: " + filename);
+    }
+    stream = ZSTD_createDStream();
+    if (!stream) {
+        fclose(file);
+        throw std::runtime_error("Failed to create ZSTD stream");
+    }
+    size_t ret = ZSTD_initDStream(stream);
+    if (ZSTD_isError(ret)) {
+        ZSTD_freeDStream(stream);
+        fclose(file);
+        throw std::runtime_error("Failed to init ZSTD stream");
+    }
+}
+
+CompressorZstd::~CompressorZstd() {
+    if (stream) ZSTD_freeDStream(stream);
+    if (file) fclose(file);
+}
+
+bool CompressorZstd::decompress(std::vector<char>& outBuffer, size_t& bytesDecompressed) {
+    if (eof) {
+        bytesDecompressed = 0;
+        return false;
+    }
+
+    ZSTD_outBuffer out{ outBuffer.data(), outBuffer.size(), 0 };
+    ZSTD_inBuffer in{ inBuffer.data(), 0, 0 };
+
+    while (out.pos < out.size) {
+        if (in.pos == in.size && !eof) {
+            in.size = fread(inBuffer.data(), 1, inBuffer.size(), file);
+            in.pos = 0;
+            if (in.size == 0) {
+                eof = true;
+                break;
+            }
+        }
+
+        size_t ret = ZSTD_decompressStream(stream, &out, &in);
+        if (ZSTD_isError(ret)) {
+            throw std::runtime_error("ZSTD decompression error");
+        }
+        if (ret == 0 && in.pos == in.size) {
+            eof = true;
+            break;
+        }
+        if (out.pos == out.size) {
+            break;
+        }
+    }
+
+    bytesDecompressed = out.pos;
+    return bytesDecompressed > 0;
+}

--- a/src/compressor_zstd.h
+++ b/src/compressor_zstd.h
@@ -1,0 +1,23 @@
+#ifndef COMPRESSOR_ZSTD_H
+#define COMPRESSOR_ZSTD_H
+
+#include <string>
+#include <vector>
+#include <zstd.h>
+#include <stdexcept>
+
+class CompressorZstd {
+public:
+    explicit CompressorZstd(const std::string& filename);
+    ~CompressorZstd();
+
+    bool decompress(std::vector<char>& outBuffer, size_t& bytesDecompressed);
+
+private:
+    FILE* file;
+    ZSTD_DStream* stream;
+    std::vector<char> inBuffer;
+    bool eof;
+};
+
+#endif // COMPRESSOR_ZSTD_H

--- a/src/tail_plain.cpp
+++ b/src/tail_plain.cpp
@@ -1,0 +1,31 @@
+#include "tail_plain.h"
+#include <fstream>
+#include <algorithm>
+#include <stdexcept>
+
+void tailPlainFile(const std::string& filename, Parser& parser, size_t n, size_t bufferSize) {
+    std::ifstream file(filename, std::ios::binary);
+    if (!file) {
+        throw std::runtime_error("Failed to open file: " + filename);
+    }
+
+    file.seekg(0, std::ios::end);
+    std::streamoff size = file.tellg();
+    std::string data;
+    std::string chunk;
+    size_t lines = 0;
+
+    while (size > 0 && lines <= n) {
+        size_t toRead = static_cast<size_t>(std::min<std::streamoff>(bufferSize, size));
+        size -= toRead;
+        file.seekg(size, std::ios::beg);
+        chunk.resize(toRead);
+        file.read(&chunk[0], toRead);
+        data.insert(0, chunk);
+        lines = std::count(data.begin(), data.end(), '\n');
+        if (size == 0) break;
+    }
+
+    parser.parse(data.data(), data.size());
+    parser.finalize();
+}

--- a/src/tail_plain.h
+++ b/src/tail_plain.h
@@ -1,0 +1,9 @@
+#ifndef TAIL_PLAIN_H
+#define TAIL_PLAIN_H
+
+#include <string>
+#include "parser.h"
+
+void tailPlainFile(const std::string& filename, Parser& parser, size_t n, size_t bufferSize);
+
+#endif

--- a/tests/test_compressor_zip.cpp
+++ b/tests/test_compressor_zip.cpp
@@ -24,7 +24,7 @@ TEST(CompressorZipTest, DecompressValidFile) {
 
     create_zip_file(filename, content);
 
-    CompressorZip compressor(filename);
+    CompressorZip compressor(filename, "test.txt");
     std::vector<char> buffer(1024);
     size_t bytesDecompressed = 0;
 

--- a/tests/test_compressor_zstd.cpp
+++ b/tests/test_compressor_zstd.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+#include "compressor_zstd.h"
+#include <zstd.h>
+#include <fstream>
+
+static void create_zst_file(const std::string& filename, const std::string& content){
+    size_t bound = ZSTD_compressBound(content.size());
+    std::vector<char> out(bound);
+    size_t compSize = ZSTD_compress(out.data(), bound, content.data(), content.size(), 1);
+    ASSERT_FALSE(ZSTD_isError(compSize));
+    std::ofstream ofs(filename, std::ios::binary);
+    ofs.write(out.data(), compSize);
+}
+
+TEST(CompressorZstdTest, DecompressValidFile){
+    const std::string filename = "test.zst";
+    const std::string content = "Line1\nLine2\n";
+    create_zst_file(filename, content);
+    CompressorZstd comp(filename);
+    std::vector<char> buf(1024);
+    size_t n = 0;
+    std::string out;
+    while (comp.decompress(buf, n)) {
+        out.append(buf.data(), n);
+    }
+    EXPECT_EQ(out, content);
+    std::remove(filename.c_str());
+}
+
+TEST(CompressorZstdTest, DecompressInvalidFile){
+    const std::string filename = "bad.zst";
+    std::ofstream ofs(filename); ofs << "bad"; ofs.close();
+    EXPECT_THROW({
+        CompressorZstd c(filename);
+        std::vector<char> buf(32);
+        size_t n = 0;
+        c.decompress(buf, n);
+    }, std::runtime_error);
+    std::remove(filename.c_str());
+}


### PR DESCRIPTION
## Summary
- centralize compression detection and add zstd support
- support multiple files and zip entry names in CLI
- add plain file optimized tail
- refactor main to use new API
- implement zstd compressor and tests
- update build with zstd and install rule

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `make -j4`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_684effa00ddc832aaea7a4b98b1be53a