### PR TITLE
Fix workflow dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,8 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake build-essential zlib1g-dev libzip-dev
+        sudo apt-get install -y cmake build-essential \
+          zlib1g-dev libbz2-dev liblzma-dev libzstd-dev libzip-dev
 
     - name: Configure CMake
       run: |

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@
 - **CMake** (version 3.10 or higher).
 - **zlib Library:** For decompressing `.gz` and `.bgz` files.
 - **bzip2 Library:** For handling `.bz2` files.
-- **liblzma Library:** For handling `.xz` files.
-- **libzip Library:** For handling `.zip` files.
+ - **liblzma Library:** For handling `.xz` files.
+ - **libzstd Library:** For handling `.zst` files.
+ - **libzip Library:** For handling `.zip` files.
 
 On Ubuntu/Debian the required packages can typically be installed with:
 
 ```bash
-sudo apt install zlib1g-dev libbz2-dev liblzma-dev libzip-dev
+sudo apt install zlib1g-dev libbz2-dev liblzma-dev libzstd-dev libzip-dev
 ```
 
 Library names may vary on other operating systems.


### PR DESCRIPTION
## Summary
- add missing dependencies in workflow
- mention zstd library in README

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_684f49a6c0dc832abcce0a849e3b509f