### PR TITLE
Implement CLI help flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,14 @@ Library names may vary on other operating systems.
 ./ztail -n 2 file.zip
 ./ztail -n 2 file.zst
 ./ztail -e entry.txt archive.zip
+./ztail --help
 ```
 
 - **`-n N`**: Display the last N lines (default = 10).
 - **`file.gz`, `file.bgz`, `file.bz2`, `file.xz`, `file.zip`, or `file.zst`**: Name of the compressed file. The extension may be omitted because compression type is detected automatically.
 - **`-e <name>`**: When reading a `.zip` file, select an entry inside the archive.
 - If no file is provided, **ztail** reads from standard input.
+- **`-h`, `--help`**: Display usage information and exit.
 
 ## 🧪 **Tests**
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -19,7 +19,11 @@ CLIOptions CLI::parse(int argc, char* argv[]) {
     CLIOptions options;
 
     for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "-n") == 0) {
+        if (std::strcmp(argv[i], "-h") == 0 || std::strcmp(argv[i], "--help") == 0) {
+            CLI::usage(argv[0]);
+            std::exit(EXIT_SUCCESS);
+        }
+        else if (std::strcmp(argv[i], "-n") == 0) {
             if (i + 1 >= argc) {
                 throw std::runtime_error("-n requires a number");
             }


### PR DESCRIPTION
## Summary
- support `-h`/`--help` flags
- document `--help` usage in README

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `make -j $(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6851fedb6edc832a99cdb63971344774