### PR TITLE
Improve header hygiene

### DIFF
--- a/src/compressor_bzip2.cpp
+++ b/src/compressor_bzip2.cpp
@@ -1,5 +1,6 @@
 #include "compressor_bzip2.h"
 #include <fstream>
+#include <stdexcept>
 
 CompressorBzip2::CompressorBzip2(const std::string& filename)
     : file(nullptr, &fclose), bz(nullptr), bzerror(BZ_OK), eof(false)

--- a/src/compressor_bzip2.h
+++ b/src/compressor_bzip2.h
@@ -4,7 +4,6 @@
 #include <bzlib.h>
 #include <string>
 #include <vector>
-#include <stdexcept>
 #include <cstdio>
 #include <memory>
 #include "icompressor.h"

--- a/src/compressor_xz.cpp
+++ b/src/compressor_xz.cpp
@@ -1,5 +1,6 @@
 #include "compressor_xz.h"
 #include <fstream>
+#include <stdexcept>
 
 CompressorXz::CompressorXz(const std::string& filename)
     : file(nullptr, &fclose), strm(LZMA_STREAM_INIT), eof(false), inBuffer(1 << 15)

--- a/src/compressor_xz.h
+++ b/src/compressor_xz.h
@@ -4,7 +4,6 @@
 #include <lzma.h>
 #include <string>
 #include <vector>
-#include <stdexcept>
 #include <cstdio>
 #include <memory>
 #include "icompressor.h"

--- a/src/compressor_zip.cpp
+++ b/src/compressor_zip.cpp
@@ -1,4 +1,5 @@
 #include "compressor_zip.h"
+#include <stdexcept>
 
 CompressorZip::CompressorZip(const std::string& filename, const std::string& entryName)
     : za(nullptr, &zip_close), zf(nullptr, &zip_fclose), entry(entryName), eof(false)

--- a/src/compressor_zip.h
+++ b/src/compressor_zip.h
@@ -3,7 +3,6 @@
 
 #include <string>
 #include <vector>
-#include <stdexcept>
 #include <zip.h>
 #include <memory>
 #include "icompressor.h"

--- a/src/compressor_zlib.cpp
+++ b/src/compressor_zlib.cpp
@@ -1,5 +1,6 @@
 #include "compressor_zlib.h"
 #include <fstream>
+#include <stdexcept>
 
 CompressorZlib::CompressorZlib(const std::string& filename)
     : gz(nullptr), eof(false)

--- a/src/compressor_zlib.h
+++ b/src/compressor_zlib.h
@@ -4,7 +4,6 @@
 #include <zlib.h>
 #include <string>
 #include <vector>
-#include <stdexcept>
 #include <memory>
 #include "icompressor.h"
 

--- a/src/compressor_zstd.cpp
+++ b/src/compressor_zstd.cpp
@@ -1,6 +1,6 @@
 #include "compressor_zstd.h"
 #include <cstdio>
-#include <cstring>
+#include <stdexcept>
 
 CompressorZstd::CompressorZstd(const std::string& filename)
     : file(nullptr, &fclose), stream(nullptr, &ZSTD_freeDStream), inBuffer(ZSTD_DStreamInSize()), eof(false)

--- a/src/compressor_zstd.h
+++ b/src/compressor_zstd.h
@@ -4,7 +4,6 @@
 #include <string>
 #include <vector>
 #include <zstd.h>
-#include <stdexcept>
 #include <memory>
 #include "icompressor.h"
 


### PR DESCRIPTION
## Summary
- drop unused `<stdexcept>` headers
- include `<stdexcept>` only in translation units that throw exceptions
- remove unused `<cstring>` include from `compressor_zstd.cpp`

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `make -j2`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_685200c3f608832aaf3ff278068781a8