### PR TITLE
Add GNU-style CLI options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION 3.16)
 # Project Name and Version
 project(ztail VERSION 1.0 LANGUAGES CXX)
 
+# Export version information to the compiler so it can be queried at runtime
+add_compile_definitions(ZTAIL_VERSION="${PROJECT_VERSION}")
+
 # Set C++ Standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/README.md
+++ b/README.md
@@ -71,13 +71,15 @@ Library names may vary on other operating systems.
 ./ztail -n 2 file.zip
 ./ztail -n 2 file.zst
 ./ztail -e entry.txt archive.zip
+./ztail --version
 ./ztail --help
 ```
 
-- **`-n N`**: Display the last N lines (default = 10).
+- **`-n N`, `--lines N`**: Display the last N lines (default = 10).
 - **`file.gz`, `file.bgz`, `file.bz2`, `file.xz`, `file.zip`, or `file.zst`**: Name of the compressed file. The extension may be omitted because compression type is detected automatically.
-- **`-e <name>`**: When reading a `.zip` file, select an entry inside the archive.
+- **`-e <name>`, `--entry <name>`**: When reading a `.zip` file, select an entry inside the archive.
 - If no file is provided, **ztail** reads from standard input.
+- **`-V`, `--version`**: Display program version and exit.
 - **`-h`, `--help`**: Display usage information and exit.
 
 ## 🧪 **Tests**


### PR DESCRIPTION
## Summary
- expose project version to C++ via `ZTAIL_VERSION`
- extend CLI parser with GNU `getopt_long`
- add `--version`, `--lines`, and `--entry` options
- document new CLI options in README

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `make`
- `ctest --output-on-failure`
- `./ztail --version`
- `./ztail --help`


------
https://chatgpt.com/codex/tasks/task_e_685202cb5b68832a960b800b21513482