### PR TITLE
feat: add portable build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,12 +24,20 @@ else()
     message(WARNING "IPO / LTO not supported: <${ipo_error}>")
 endif()
 
+# Option to build portable binaries
+option(BUILD_PORTABLE "Build without native CPU optimizations" OFF)
+
 # Compiler Optimization Flags
 add_compile_options(
     -O3
-    -march=native
     -pipe
 )
+
+if(BUILD_PORTABLE)
+    add_compile_options(-mtune=generic)
+else()
+    add_compile_options(-march=native)
+endif()
 
 if(ipo_supported)
     add_compile_options(-flto)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ Library names may vary on other operating systems.
    cmake .. -DBUILD_TESTING=ON
    ```
 
+   To generate a portable binary that avoids CPU-specific optimizations, enable the
+   `BUILD_PORTABLE` option:
+
+   ```bash
+   cmake .. -DBUILD_PORTABLE=ON
+   ```
+
 4. **Build the Project:**
 
    ```bash


### PR DESCRIPTION
## Summary
- add optional BUILD_PORTABLE flag to use generic CPU tuning instead of `-march=native`
- document how to enable portable builds in the README

## Testing
- `cmake .. -DBUILD_TESTING=ON -DBUILD_PORTABLE=ON`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_689d86003ca0832a97f02773e8cc151f