### PR TITLE
feat: add optional line capacity to CircularBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Library names may vary on other operating systems.
 
 ```bash
 ./ztail -n 2 file.gz
+./ztail -n 2 -c 1024 file.gz
 ./ztail -n 2 file.bgz
 ./ztail -n 2 file.bz2
 ./ztail -n 2 file.xz
@@ -83,6 +84,7 @@ Library names may vary on other operating systems.
 ```
 
 - **`-n N`, `--lines N`**: Display the last N lines (default = 10).
+- **`-c N`, `--line-capacity N`**: Pre-reserve N bytes for each line to reduce reallocations (default = 0).
 - **`file.gz`, `file.bgz`, `file.bz2`, `file.xz`, `file.zip`, or `file.zst`**: Name of the compressed file. The extension may be omitted because compression type is detected automatically.
 - **`-e <name>`, `--entry <name>`**: When reading a `.zip` file, select an entry inside the archive.
 - If no file is provided, **ztail** reads from standard input.

--- a/src/circular_buffer.cpp
+++ b/src/circular_buffer.cpp
@@ -1,12 +1,14 @@
 #include "circular_buffer.h"
 #include <iostream>
 
-CircularBuffer::CircularBuffer(size_t cap)
+CircularBuffer::CircularBuffer(size_t cap, size_t lineCapacity)
     : buffer(cap), capacity(cap), next(0), count(0)
 {
-    // Reserve initial capacity for each string to avoid repeated allocations
-    for (auto& s : buffer) {
-        s.reserve(1024);
+    // Reserve initial capacity for each string when requested
+    if (lineCapacity > 0) {
+        for (auto& s : buffer) {
+            s.reserve(lineCapacity);
+        }
     }
 }
 

--- a/src/circular_buffer.h
+++ b/src/circular_buffer.h
@@ -6,7 +6,7 @@
 
 class CircularBuffer {
 public:
-    explicit CircularBuffer(size_t capacity);
+    explicit CircularBuffer(size_t capacity, size_t lineCapacity = 0);
     void add(std::string&& line);
     void print() const;
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -11,6 +11,7 @@ void CLI::usage(const char* progName) {
     std::cerr
         << "Usage: " << progName << " [options] <files...>\n"
         << "  -n, --lines N   : print the last N lines (default = 10)\n"
+        << "  -c, --line-capacity N : pre-reserve N bytes for each line\n"
         << "  -e, --entry <name> : entry name inside zip archive\n"
         << "  -V, --version  : display program version and exit\n"
         << "  -h, --help     : display this help and exit\n"
@@ -22,15 +23,16 @@ CLIOptions CLI::parse(int argc, char* argv[]) {
     CLIOptions options;
 
     static struct option long_opts[] = {
-        {"help",    no_argument,       nullptr, 'h'},
-        {"version", no_argument,       nullptr, 'V'},
-        {"lines",   required_argument, nullptr, 'n'},
-        {"entry",   required_argument, nullptr, 'e'},
+        {"help",          no_argument,       nullptr, 'h'},
+        {"version",       no_argument,       nullptr, 'V'},
+        {"lines",         required_argument, nullptr, 'n'},
+        {"line-capacity", required_argument, nullptr, 'c'},
+        {"entry",         required_argument, nullptr, 'e'},
         {0, 0, 0, 0}
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "hn:e:V", long_opts, nullptr)) != -1) {
+    while ((opt = getopt_long(argc, argv, "hn:c:e:V", long_opts, nullptr)) != -1) {
         switch (opt) {
         case 'h':
             CLI::usage(argv[0]);
@@ -47,6 +49,16 @@ CLIOptions CLI::parse(int argc, char* argv[]) {
                 throw std::runtime_error("-n/--lines requires a positive integer");
             }
             options.n = static_cast<int>(val);
+            break;
+        }
+        case 'c': {
+            char* end = nullptr;
+            errno = 0;
+            long val = std::strtol(optarg, &end, 10);
+            if (errno != 0 || end == optarg || *end != '\0' || val < 0) {
+                throw std::runtime_error("-c/--line-capacity requires a non-negative integer");
+            }
+            options.lineCapacity = static_cast<size_t>(val);
             break;
         }
         case 'e':

--- a/src/cli.h
+++ b/src/cli.h
@@ -6,6 +6,7 @@
 
 struct CLIOptions {
     int n = 10;             // Number of lines to print (default = 10)
+    size_t lineCapacity = 0; // Optional pre-reserve size for each line
     std::vector<std::string> filenames;   // Names of files to process
     std::string zipEntry;   // Optional entry name for zip files
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,7 +25,7 @@ int main(int argc, char* argv[]) {
 
         if (!options.filenames.empty()) {
             for (const auto& filename : options.filenames) {
-                CircularBuffer cb(options.n);
+                CircularBuffer cb(options.n, options.lineCapacity);
                 Parser parser(cb);
                 std::vector<char> buffer(READ_BUFFER_SIZE);
                 size_t bytesDecompressed = 0;
@@ -59,7 +59,7 @@ int main(int argc, char* argv[]) {
                 cb.print();
             }
         } else {
-            CircularBuffer cb(options.n);
+            CircularBuffer cb(options.n, options.lineCapacity);
             Parser parser(cb);
             std::vector<char> buffer(READ_BUFFER_SIZE);
             while (true) {

--- a/tests/test_circular_buffer.cpp
+++ b/tests/test_circular_buffer.cpp
@@ -2,7 +2,7 @@
 #include "circular_buffer.h"
 
 TEST(CircularBufferTest, AddAndRetrieve) {
-    CircularBuffer cb(3);
+    CircularBuffer cb(3, 16);
     cb.add("Line 1");
     cb.add("Line 2");
     cb.add("Line 3");

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -3,7 +3,7 @@
 #include "circular_buffer.h"
 
 TEST(ParserTest, ParseLines) {
-    CircularBuffer cb(5);
+    CircularBuffer cb(5, 16);
     Parser parser(cb);
 
     const char* data = "Line A\nLine B\nLine C\n";
@@ -18,7 +18,7 @@ TEST(ParserTest, ParseLines) {
 }
 
 TEST(ParserTest, ParseWithPartialLine) {
-    CircularBuffer cb(5);
+    CircularBuffer cb(5, 16);
     Parser parser(cb);
 
     const char* data = "Line A\nLine B";


### PR DESCRIPTION
## Summary
- allow optional pre-reserved line capacity when creating `CircularBuffer`
- expose `-c/--line-capacity` CLI flag and propagate to main
- document new CLI option and update tests

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON`
- `cmake --build build`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_689d8b792a10832a903686a33c0d30c4