### PR TITLE
Add CharRingBuffer and benchmarking tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 
 # Option to build portable binaries
 option(BUILD_PORTABLE "Build without native CPU optimizations" OFF)
+option(USE_CHAR_RING_BUFFER "Use CharRingBuffer instead of std::string CircularBuffer" OFF)
 
 # Compiler Optimization Flags
 add_compile_options(
@@ -100,6 +101,7 @@ include(CTest)
 # Source Files
 set(ZTAIL_LIB_SOURCES
     src/circular_buffer.cpp
+    src/char_ring_buffer.cpp
     src/cli.cpp
     src/compressor_zlib.cpp
     src/compressor_bzip2.cpp
@@ -122,6 +124,9 @@ target_link_libraries(ztail_lib
         ${LIBZSTD_LIBRARIES}
 )
 target_include_directories(ztail_lib PUBLIC src)
+if(USE_CHAR_RING_BUFFER)
+    target_compile_definitions(ztail_lib PUBLIC USE_CHAR_RING_BUFFER)
+endif()
 
 # Executable
 add_executable(ztail src/main.cpp)
@@ -141,6 +146,8 @@ if(BUILD_TESTING)
 
     add_executable(ztail_tests
         tests/test_circular_buffer.cpp
+        tests/test_char_ring_buffer.cpp
+        tests/test_buffer_bench.cpp
         tests/test_compressor_zlib.cpp
         tests/test_compressor_bzip2.cpp
         tests/test_compressor_xz.cpp
@@ -152,6 +159,9 @@ if(BUILD_TESTING)
     )
     target_link_libraries(ztail_tests PRIVATE gtest_main ztail_lib)
     target_compile_definitions(ztail_tests PRIVATE ZTAIL_NO_MAIN)
+    if(USE_CHAR_RING_BUFFER)
+        target_compile_definitions(ztail_tests PRIVATE USE_CHAR_RING_BUFFER)
+    endif()
 
     include(GoogleTest)
     gtest_discover_tests(ztail_tests)

--- a/src/char_ring_buffer.cpp
+++ b/src/char_ring_buffer.cpp
@@ -1,0 +1,50 @@
+#include "char_ring_buffer.h"
+#include <iostream>
+
+CharRingBuffer::CharRingBuffer(size_t cap, size_t lineCapacity)
+    : data(), offsets(), capacity(cap), count(0)
+{
+    if (capacity > 0 && lineCapacity > 0) {
+        data.reserve(capacity * lineCapacity);
+    }
+    offsets.reserve(capacity);
+}
+
+void CharRingBuffer::add(std::string&& line) {
+    if (capacity == 0) {
+        return;
+    }
+    // if we have space for more lines
+    if (count < capacity) {
+        offsets.push_back(data.size());
+        data.insert(data.end(), line.begin(), line.end());
+        count++;
+    } else {
+        // remove first line
+        size_t first_start = offsets[0];
+        size_t first_end = (count > 1) ? offsets[1] : data.size();
+        size_t first_len = first_end - first_start;
+        // erase first line from data
+        data.erase(data.begin(), data.begin() + first_len);
+        // shift offsets left
+        for (size_t i = 1; i < offsets.size(); ++i) {
+            offsets[i - 1] = offsets[i] - first_len;
+        }
+        offsets[count - 1] = data.size();
+        data.insert(data.end(), line.begin(), line.end());
+    }
+}
+
+void CharRingBuffer::print() const {
+    for (size_t i = 0; i < count; ++i) {
+        size_t start = offsets[i];
+        size_t end = (i + 1 < count) ? offsets[i + 1] : data.size();
+        std::cout.write(&data[start], end - start);
+        std::cout.put('\n');
+    }
+}
+
+size_t CharRingBuffer::memoryUsage() const {
+    return sizeof(CharRingBuffer) + data.capacity() * sizeof(char) + offsets.capacity() * sizeof(size_t);
+}
+

--- a/src/char_ring_buffer.h
+++ b/src/char_ring_buffer.h
@@ -1,0 +1,22 @@
+#ifndef CHAR_RING_BUFFER_H
+#define CHAR_RING_BUFFER_H
+
+#include <vector>
+#include <string>
+#include <cstddef>
+
+class CharRingBuffer {
+public:
+    explicit CharRingBuffer(size_t capacity, size_t lineCapacity = 0);
+    void add(std::string&& line);
+    void print() const;
+    size_t memoryUsage() const;
+
+private:
+    std::vector<char> data;
+    std::vector<size_t> offsets; // start positions of lines within data
+    size_t capacity;
+    size_t count;
+};
+
+#endif // CHAR_RING_BUFFER_H

--- a/src/circular_buffer.cpp
+++ b/src/circular_buffer.cpp
@@ -1,3 +1,4 @@
+#ifndef USE_CHAR_RING_BUFFER
 #include "circular_buffer.h"
 #include <iostream>
 
@@ -32,3 +33,13 @@ void CircularBuffer::print() const {
         std::cout << buffer[idx] << "\n";
     }
 }
+
+size_t CircularBuffer::memoryUsage() const {
+    size_t total = sizeof(CircularBuffer) + buffer.capacity() * sizeof(std::string);
+    for (const auto& s : buffer) {
+        total += s.capacity();
+    }
+    return total;
+}
+
+#endif // USE_CHAR_RING_BUFFER

--- a/src/circular_buffer.h
+++ b/src/circular_buffer.h
@@ -4,11 +4,17 @@
 #include <string>
 #include <vector>
 
+#ifdef USE_CHAR_RING_BUFFER
+#include "char_ring_buffer.h"
+using CircularBuffer = CharRingBuffer;
+#else
+
 class CircularBuffer {
 public:
     explicit CircularBuffer(size_t capacity, size_t lineCapacity = 0);
     void add(std::string&& line);
     void print() const;
+    size_t memoryUsage() const;
 
 private:
     std::vector<std::string> buffer;
@@ -16,5 +22,7 @@ private:
     size_t next;
     size_t count;
 };
+
+#endif // USE_CHAR_RING_BUFFER
 
 #endif // CIRCULAR_BUFFER_H

--- a/tests/test_buffer_bench.cpp
+++ b/tests/test_buffer_bench.cpp
@@ -1,0 +1,44 @@
+#include <gtest/gtest.h>
+#include "circular_buffer.h"
+#include "char_ring_buffer.h"
+#include <chrono>
+#include <string>
+#include <iostream>
+
+TEST(BufferBenchmark, PerformanceComparison) {
+    const size_t lines = 10000;
+    std::string sample = "Sample line";
+
+    CircularBuffer cb(lines, sample.size());
+    CharRingBuffer crb(lines, sample.size());
+
+    auto start = std::chrono::high_resolution_clock::now();
+    for (size_t i = 0; i < lines; ++i) {
+        cb.add("Sample line");
+    }
+    auto mid = std::chrono::high_resolution_clock::now();
+    for (size_t i = 0; i < lines; ++i) {
+        crb.add("Sample line");
+    }
+    auto end = std::chrono::high_resolution_clock::now();
+
+    auto cbTime = std::chrono::duration_cast<std::chrono::microseconds>(mid - start).count();
+    auto crbTime = std::chrono::duration_cast<std::chrono::microseconds>(end - mid).count();
+    std::cout << "CircularBuffer add time: " << cbTime << "us\n";
+    std::cout << "CharRingBuffer add time: " << crbTime << "us\n";
+}
+
+TEST(BufferBenchmark, MemoryUsageComparison) {
+    const size_t lines = 1000;
+    CircularBuffer cb(lines, 20);
+    CharRingBuffer crb(lines, 20);
+    for (size_t i = 0; i < lines; ++i) {
+        cb.add(std::string(20, 'x'));
+        crb.add(std::string(20, 'x'));
+    }
+    size_t memCb = cb.memoryUsage();
+    size_t memCrb = crb.memoryUsage();
+    std::cout << "CircularBuffer memory: " << memCb << " bytes\n";
+    std::cout << "CharRingBuffer memory: " << memCrb << " bytes\n";
+    EXPECT_LE(memCrb, memCb);
+}

--- a/tests/test_char_ring_buffer.cpp
+++ b/tests/test_char_ring_buffer.cpp
@@ -1,0 +1,29 @@
+#include <gtest/gtest.h>
+#include "char_ring_buffer.h"
+
+TEST(CharRingBufferTest, AddAndRetrieve) {
+    CharRingBuffer cb(3, 16);
+    cb.add("Line 1");
+    cb.add("Line 2");
+    cb.add("Line 3");
+    cb.add("Line 4"); // Overwrites "Line 1"
+
+    testing::internal::CaptureStdout();
+    cb.print();
+    std::string output = testing::internal::GetCapturedStdout();
+
+    std::string expected = "Line 2\nLine 3\nLine 4\n";
+    EXPECT_EQ(output, expected);
+}
+
+TEST(CharRingBufferTest, EmptyBuffer) {
+    CharRingBuffer cb(0);
+    cb.add("Line 1");
+    cb.add("Line 2");
+
+    testing::internal::CaptureStdout();
+    cb.print();
+    std::string output = testing::internal::GetCapturedStdout();
+
+    EXPECT_EQ(output, "");
+}


### PR DESCRIPTION
## Summary
- implement CharRingBuffer using contiguous char storage and offset array
- expose memory usage for buffer types and add compile-time switch
- add performance and memory comparison tests for string vs char ring buffers

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_689d8d45ec8c832a954a8ad1eb15d530