### PR TITLE
Allow parser line capacity configuration

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,7 +26,7 @@ int main(int argc, char* argv[]) {
         if (!options.filenames.empty()) {
             for (const auto& filename : options.filenames) {
                 CircularBuffer cb(options.n, options.lineCapacity);
-                Parser parser(cb);
+                Parser parser(cb, options.lineCapacity);
                 std::vector<char> buffer(READ_BUFFER_SIZE);
                 size_t bytesDecompressed = 0;
 
@@ -60,7 +60,7 @@ int main(int argc, char* argv[]) {
             }
         } else {
             CircularBuffer cb(options.n, options.lineCapacity);
-            Parser parser(cb);
+            Parser parser(cb, options.lineCapacity);
             std::vector<char> buffer(READ_BUFFER_SIZE);
             while (true) {
                 size_t bytesRead = std::fread(buffer.data(), 1, buffer.size(), stdin);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,10 +1,12 @@
 #include "parser.h"
 #include <cstring> // memchr
 
-Parser::Parser(CircularBuffer& cb)
+Parser::Parser(CircularBuffer& cb, size_t lineCapacity)
     : circularBuffer(cb)
 {
-    partial.reserve(1024);
+    if (lineCapacity > 0) {
+        partial.reserve(lineCapacity);
+    }
 }
 
 void Parser::parse(const char* data, size_t size) {

--- a/src/parser.h
+++ b/src/parser.h
@@ -8,7 +8,7 @@
 // (separated by '\n') and adding them to the CircularBuffer.
 class Parser {
 public:
-    explicit Parser(CircularBuffer& cb);
+    explicit Parser(CircularBuffer& cb, size_t lineCapacity = 0);
 
     // Processes a chunk of data, splitting by '\n'
     void parse(const char* data, size_t size);

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -4,7 +4,7 @@
 
 TEST(ParserTest, ParseLines) {
     CircularBuffer cb(5, 16);
-    Parser parser(cb);
+    Parser parser(cb, 16);
 
     const char* data = "Line A\nLine B\nLine C\n";
     parser.parse(data, strlen(data));
@@ -19,7 +19,7 @@ TEST(ParserTest, ParseLines) {
 
 TEST(ParserTest, ParseWithPartialLine) {
     CircularBuffer cb(5, 16);
-    Parser parser(cb);
+    Parser parser(cb, 16);
 
     const char* data = "Line A\nLine B";
     parser.parse(data, strlen(data));


### PR DESCRIPTION
## Summary
- add optional `lineCapacity` parameter to `Parser`
- reserve partial buffer only when `lineCapacity` is positive
- propagate new constructor through `main` and parser tests

## Testing
- `cmake -S .. -B build -D BUILD_TESTING=ON`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_689d8f513da8832ab187176e7f2c269e