### PR TITLE
perf: disable iostream sync

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,8 @@ static const size_t READ_BUFFER_SIZE = 1 << 20; // 1MB
 
 #ifndef ZTAIL_NO_MAIN
 int main(int argc, char* argv[]) {
+    std::ios::sync_with_stdio(false);
+    std::cout.tie(nullptr);
     try {
         CLIOptions options = CLI::parse(argc, argv);
 


### PR DESCRIPTION
## Summary
- disable iostream sync and untie `cout` in `main` for better IO performance

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_689dace1fa88832a97c0e650af131878