### PR TITLE
Optimize buffer printing

### DIFF
--- a/src/char_ring_buffer.cpp
+++ b/src/char_ring_buffer.cpp
@@ -36,12 +36,18 @@ void CharRingBuffer::add(std::string&& line) {
 }
 
 void CharRingBuffer::print() const {
+    if (count == 0) {
+        return;
+    }
+    std::string output;
+    output.reserve(data.size() + count);
     for (size_t i = 0; i < count; ++i) {
         size_t start = offsets[i];
         size_t end = (i + 1 < count) ? offsets[i + 1] : data.size();
-        std::cout.write(&data[start], end - start);
-        std::cout.put('\n');
+        output.append(&data[start], end - start);
+        output.push_back('\n');
     }
+    std::cout.write(output.data(), static_cast<std::streamsize>(output.size()));
 }
 
 size_t CharRingBuffer::memoryUsage() const {

--- a/src/circular_buffer.cpp
+++ b/src/circular_buffer.cpp
@@ -27,11 +27,23 @@ void CircularBuffer::add(std::string&& line) {
 }
 
 void CircularBuffer::print() const {
+    if (count == 0) {
+        return;
+    }
     size_t start = (next >= count) ? (next - count) : (capacity + next - count);
+    size_t totalLen = 0;
     for (size_t i = 0; i < count; ++i) {
         size_t idx = (start + i) % capacity;
-        std::cout << buffer[idx] << "\n";
+        totalLen += buffer[idx].size() + 1; // include newline
     }
+    std::string output;
+    output.reserve(totalLen);
+    for (size_t i = 0; i < count; ++i) {
+        size_t idx = (start + i) % capacity;
+        output.append(buffer[idx]);
+        output.push_back('\n');
+    }
+    std::cout.write(output.data(), static_cast<std::streamsize>(output.size()));
 }
 
 size_t CircularBuffer::memoryUsage() const {


### PR DESCRIPTION
## Summary
- Aggregate buffer lines into a single string in `CircularBuffer::print` and `CharRingBuffer::print`
- Write buffer content to stdout in one call for efficiency

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_689daead8830832a96d075aaa96a5950