### PR TITLE
feat: add configurable read buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Library names may vary on other operating systems.
 
 - **`-n N`, `--lines N`**: Display the last N lines (default = 10).
 - **`-c N`, `--line-capacity N`**: Pre-reserve N bytes for each line to reduce reallocations (default = 0).
+- **`-r N`, `--read-buffer N`**: Set read buffer size in bytes (default = 1048576).
 - **`file.gz`, `file.bgz`, `file.bz2`, `file.xz`, `file.zip`, or `file.zst`**: Name of the compressed file. The extension may be omitted because compression type is detected automatically.
 - **`-e <name>`, `--entry <name>`**: When reading a `.zip` file, select an entry inside the archive.
 - If no file is provided, **ztail** reads from standard input.

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -13,6 +13,7 @@ void CLI::usage(const char* progName) {
         << "  -n, --lines N   : print the last N lines (default = 10)\n"
         << "  -c, --line-capacity N : pre-reserve N bytes for each line\n"
         << "  -b, --zlib-buffer N : set zlib buffer size in bytes (default = 1048576)\n"
+        << "  -r, --read-buffer N : set read buffer size in bytes (default = 1048576)\n"
         << "  -e, --entry <name> : entry name inside zip archive\n"
         << "  -V, --version  : display program version and exit\n"
         << "  -h, --help     : display this help and exit\n"
@@ -29,12 +30,13 @@ CLIOptions CLI::parse(int argc, char* argv[]) {
         {"lines",         required_argument, nullptr, 'n'},
         {"line-capacity", required_argument, nullptr, 'c'},
         {"zlib-buffer",   required_argument, nullptr, 'b'},
+        {"read-buffer",   required_argument, nullptr, 'r'},
         {"entry",         required_argument, nullptr, 'e'},
         {0, 0, 0, 0}
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "hn:c:b:e:V", long_opts, nullptr)) != -1) {
+    while ((opt = getopt_long(argc, argv, "hn:c:b:r:e:V", long_opts, nullptr)) != -1) {
         switch (opt) {
         case 'h':
             CLI::usage(argv[0]);
@@ -73,6 +75,16 @@ CLIOptions CLI::parse(int argc, char* argv[]) {
                                          std::to_string(std::numeric_limits<unsigned int>::max()));
             }
             options.zlibBufferSize = static_cast<size_t>(val);
+            break;
+        }
+        case 'r': {
+            char* end = nullptr;
+            errno = 0;
+            long val = std::strtol(optarg, &end, 10);
+            if (errno != 0 || end == optarg || *end != '\0' || val <= 0) {
+                throw std::runtime_error("-r/--read-buffer requires a positive integer");
+            }
+            options.readBufferSize = static_cast<size_t>(val);
             break;
         }
         case 'e':

--- a/src/cli.h
+++ b/src/cli.h
@@ -10,6 +10,7 @@ struct CLIOptions {
     std::vector<std::string> filenames;   // Names of files to process
     std::string zipEntry;   // Optional entry name for zip files
     size_t zlibBufferSize = 1 << 20; // Buffer size for zlib operations
+    size_t readBufferSize = 1 << 20; // Buffer size for reading files
 };
 
 class CLI {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,8 +16,6 @@
 #include <vector>
 #include <cstdlib>     // for EXIT_SUCCESS/EXIT_FAILURE
 
-static const size_t READ_BUFFER_SIZE = 1 << 20; // 1MB
-
 #ifndef ZTAIL_NO_MAIN
 int main(int argc, char* argv[]) {
     std::ios::sync_with_stdio(false);
@@ -29,7 +27,7 @@ int main(int argc, char* argv[]) {
             for (const auto& filename : options.filenames) {
                 CircularBuffer cb(options.n, options.lineCapacity);
                 Parser parser(cb, options.lineCapacity);
-                std::vector<char> buffer(READ_BUFFER_SIZE);
+                std::vector<char> buffer(options.readBufferSize);
                 size_t bytesDecompressed = 0;
 
                 DetectionResult det = detectCompressionType(filename);
@@ -55,7 +53,7 @@ int main(int argc, char* argv[]) {
                     parser.finalize();
                 } else {
                     det.file.reset();
-                    tailPlainFile(filename, parser, options.n, READ_BUFFER_SIZE);
+                    tailPlainFile(filename, parser, options.n, options.readBufferSize);
                 }
 
                 cb.print();
@@ -63,7 +61,7 @@ int main(int argc, char* argv[]) {
         } else {
             CircularBuffer cb(options.n, options.lineCapacity);
             Parser parser(cb, options.lineCapacity);
-            std::vector<char> buffer(READ_BUFFER_SIZE);
+            std::vector<char> buffer(options.readBufferSize);
             while (true) {
                 size_t bytesRead = std::fread(buffer.data(), 1, buffer.size(), stdin);
                 if (bytesRead == 0) break;


### PR DESCRIPTION
## Summary
- add `-r/--read-buffer` CLI option to set input buffer size
- use configurable buffer size throughout main logic instead of fixed constant
- document read buffer flag in README

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_689db0107680832aa274bb9a3e2c2709