### PR TITLE
refactor: implement circular byte buffer in CharRingBuffer

### DIFF
--- a/src/char_ring_buffer.cpp
+++ b/src/char_ring_buffer.cpp
@@ -1,56 +1,88 @@
 #include "char_ring_buffer.h"
 #include <iostream>
+#include <algorithm>
 
 CharRingBuffer::CharRingBuffer(size_t cap, size_t lineCapacity)
-    : data(), offsets(), capacity(cap), count(0)
+    : data(), offsets(cap), capacity(cap), start(0), end(0), offsetStart(0), count(0)
 {
     if (capacity > 0 && lineCapacity > 0) {
-        data.reserve(capacity * lineCapacity);
+        data.resize(capacity * lineCapacity);
     }
-    offsets.reserve(capacity);
 }
 
 void CharRingBuffer::add(std::string&& line) {
-    if (capacity == 0) {
+    if (capacity == 0 || data.empty()) {
         return;
     }
-    // if we have space for more lines
-    if (count < capacity) {
-        offsets.push_back(data.size());
-        data.insert(data.end(), line.begin(), line.end());
-        count++;
-    } else {
-        // remove first line
-        size_t first_start = offsets[0];
-        size_t first_end = (count > 1) ? offsets[1] : data.size();
-        size_t first_len = first_end - first_start;
-        // erase first line from data
-        data.erase(data.begin(), data.begin() + first_len);
-        // shift offsets left
-        for (size_t i = 1; i < offsets.size(); ++i) {
-            offsets[i - 1] = offsets[i] - first_len;
-        }
-        offsets[count - 1] = data.size();
-        data.insert(data.end(), line.begin(), line.end());
+
+    const size_t dataCap = data.size();
+    const size_t lineLen = line.size();
+    if (lineLen > dataCap) {
+        return; // line too large to fit, ignore
     }
+
+    auto freeSpace = [&]() {
+        size_t used = (end >= start) ? end - start : dataCap - (start - end);
+        return dataCap - used;
+    };
+
+    // ensure there is space and room for a new line slot
+    while (count == capacity || freeSpace() < lineLen) {
+        if (count == 0) break;
+        size_t first_start = start;
+        size_t second_start = (count > 1) ? offsets[(offsetStart + 1) % capacity] : end;
+        size_t first_len = (second_start >= first_start)
+                               ? (second_start - first_start)
+                               : (dataCap - first_start + second_start);
+        start = second_start;
+        offsetStart = (offsetStart + 1) % capacity;
+        count--;
+    }
+
+    size_t insert_pos = end;
+    if (end + lineLen <= dataCap) {
+        std::copy(line.begin(), line.end(), data.begin() + end);
+        end = (end + lineLen) % dataCap;
+    } else {
+        size_t first_part = dataCap - end;
+        std::copy(line.begin(), line.begin() + first_part, data.begin() + end);
+        std::copy(line.begin() + first_part, line.end(), data.begin());
+        end = lineLen - first_part;
+    }
+
+    offsets[(offsetStart + count) % capacity] = insert_pos;
+    if (count == 0) {
+        start = insert_pos;
+    }
+    count++;
 }
 
 void CharRingBuffer::print() const {
     if (count == 0) {
         return;
     }
+    const size_t dataCap = data.size();
     std::string output;
-    output.reserve(data.size() + count);
+    output.reserve(dataCap + count);
+
     for (size_t i = 0; i < count; ++i) {
-        size_t start = offsets[i];
-        size_t end = (i + 1 < count) ? offsets[i + 1] : data.size();
-        output.append(&data[start], end - start);
+        size_t idx = (offsetStart + i) % capacity;
+        size_t nextIdx = (i + 1 < count) ? (offsetStart + i + 1) % capacity : idx;
+        size_t startPos = offsets[idx];
+        size_t endPos = (i + 1 < count) ? offsets[nextIdx] : end;
+
+        if (startPos <= endPos) {
+            output.append(&data[startPos], endPos - startPos);
+        } else {
+            output.append(&data[startPos], dataCap - startPos);
+            output.append(&data[0], endPos);
+        }
         output.push_back('\n');
     }
     std::cout.write(output.data(), static_cast<std::streamsize>(output.size()));
 }
 
 size_t CharRingBuffer::memoryUsage() const {
-    return sizeof(CharRingBuffer) + data.capacity() * sizeof(char) + offsets.capacity() * sizeof(size_t);
+    return sizeof(CharRingBuffer) + data.size() * sizeof(char) + offsets.size() * sizeof(size_t);
 }
 

--- a/src/char_ring_buffer.h
+++ b/src/char_ring_buffer.h
@@ -13,10 +13,13 @@ public:
     size_t memoryUsage() const;
 
 private:
-    std::vector<char> data;
-    std::vector<size_t> offsets; // start positions of lines within data
-    size_t capacity;
-    size_t count;
+    std::vector<char> data;             // underlying byte storage
+    std::vector<size_t> offsets;        // ring of line start positions
+    size_t capacity;                    // maximum number of lines
+    size_t start;                       // index of first byte in data
+    size_t end;                         // index one past the last byte
+    size_t offsetStart;                 // index of first entry in offsets
+    size_t count;                       // current number of lines
 };
 
 #endif // CHAR_RING_BUFFER_H


### PR DESCRIPTION
## Summary
- replace data erase/shift with start/end pointer circular buffer
- manage line offsets as a ring to avoid copying

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_689db1f56524832aad19adadee320c36