### PR TITLE
feat: enable CharRingBuffer backend by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,15 @@ endif()
 
 # Option to build portable binaries
 option(BUILD_PORTABLE "Build without native CPU optimizations" OFF)
-option(USE_CHAR_RING_BUFFER "Use CharRingBuffer instead of std::string CircularBuffer" OFF)
+option(USE_CHAR_RING_BUFFER "Use CharRingBuffer instead of std::string CircularBuffer" ON)
 option(ZTAIL_USE_THREADS "Enable producer/consumer threading" ON)
+
+# Display selected buffer backend
+if(USE_CHAR_RING_BUFFER)
+    message(STATUS "Using CharRingBuffer backend (default)")
+else()
+    message(STATUS "Using std::string CircularBuffer backend (debug)")
+endif()
 
 # Compiler Optimization Flags
 add_compile_options(

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 - **Automatic Detection:** Compression type is identified from file contents even when the extension is missing or wrong.
 - **High Performance:** Optimized for large files, avoiding unnecessary full decompressions.
 - **Intuitive Command-Line Interface:** Simple usage with flexible options.
+- **Efficient Ring Buffer:** Uses a CharRingBuffer backend by default. Build with `-DUSE_CHAR_RING_BUFFER=OFF` to
+  switch to the slower std::string-based buffer for debugging purposes.
 
 ## 📦 **Installation**
 
@@ -63,6 +65,13 @@ Library names may vary on other operating systems.
 
    ```bash
    cmake .. -DZTAIL_USE_THREADS=OFF
+   ```
+
+   The high-performance CharRingBuffer backend is enabled by default. To use the previous
+   std::string-based implementation for debugging, disable it with:
+
+   ```bash
+   cmake .. -DUSE_CHAR_RING_BUFFER=OFF
    ```
 
 4. **Build the Project:**

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -18,7 +18,9 @@ void CLI::usage(const char* progName) {
         << "  -V, --version  : display program version and exit\n"
         << "  -h, --help     : display this help and exit\n"
         << "If no file is provided, the program reads from stdin.\n"
-        << "Compression type is detected automatically.\n";
+        << "Compression type is detected automatically.\n"
+        << "CharRingBuffer backend is enabled by default. Build with -DUSE_CHAR_RING_BUFFER=OFF to\n"
+           "use the std::string-based buffer for debugging.\n";
 }
 
 CLIOptions CLI::parse(int argc, char* argv[]) {


### PR DESCRIPTION
## Summary
- default to CharRingBuffer backend with build-time message
- document new default and update CLI help

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a8561310d4832a9987444b54bd95bc