### PR TITLE
Use 64‑bit offsets for large ring buffers

### DIFF
--- a/src/char_ring_buffer.cpp
+++ b/src/char_ring_buffer.cpp
@@ -2,7 +2,8 @@
 #include <iostream>
 #include <algorithm>
 
-CharRingBuffer::CharRingBuffer(size_t cap, size_t lineCapacity)
+template <size_t MaxBytes>
+CharRingBuffer<MaxBytes>::CharRingBuffer(size_t cap, size_t lineCapacity)
     : data(), offsets(cap), capacity(cap), start(0), end(0), offsetStart(0),
       count(0), lineInProgress(false), currentLineStart(0)
 {
@@ -11,12 +12,14 @@ CharRingBuffer::CharRingBuffer(size_t cap, size_t lineCapacity)
     }
 }
 
-void CharRingBuffer::add(std::string&& line) {
+template <size_t MaxBytes>
+void CharRingBuffer<MaxBytes>::add(std::string&& line) {
     append_segment(line.data(), line.size());
     end_line();
 }
 
-void CharRingBuffer::append_segment(const char* segment, size_t len) {
+template <size_t MaxBytes>
+void CharRingBuffer<MaxBytes>::append_segment(const char* segment, size_t len) {
     if (capacity == 0 || data.empty() || len == 0) {
         return;
     }
@@ -27,13 +30,15 @@ void CharRingBuffer::append_segment(const char* segment, size_t len) {
     }
 
     auto freeSpace = [&]() {
-        size_t used = (end >= start) ? end - start : dataCap - (start - end);
+        size_t s = static_cast<size_t>(start);
+        size_t e = static_cast<size_t>(end);
+        size_t used = (e >= s) ? e - s : dataCap - (s - e);
         return dataCap - used;
     };
 
     auto drop_oldest = [&]() {
         if (count == 0) return;
-        size_t second_start = (count > 1) ? offsets[(offsetStart + 1) % capacity] : end;
+        Offset second_start = (count > 1) ? offsets[(offsetStart + 1) % capacity] : end;
         start = second_start;
         offsetStart = (offsetStart + 1) % capacity;
         count--;
@@ -56,18 +61,20 @@ void CharRingBuffer::append_segment(const char* segment, size_t len) {
         return; // not enough space even after dropping
     }
 
-    if (end + len <= dataCap) {
-        std::copy(segment, segment + len, data.begin() + end);
-        end = (end + len) % dataCap;
+    size_t e = static_cast<size_t>(end);
+    if (e + len <= dataCap) {
+        std::copy(segment, segment + len, data.begin() + e);
+        end = static_cast<Offset>((e + len) % dataCap);
     } else {
-        size_t first_part = dataCap - end;
-        std::copy(segment, segment + first_part, data.begin() + end);
+        size_t first_part = dataCap - e;
+        std::copy(segment, segment + first_part, data.begin() + e);
         std::copy(segment + first_part, segment + len, data.begin());
-        end = len - first_part;
+        end = static_cast<Offset>(len - first_part);
     }
 }
 
-void CharRingBuffer::end_line() {
+template <size_t MaxBytes>
+void CharRingBuffer<MaxBytes>::end_line() {
     if (capacity == 0 || data.empty()) {
         lineInProgress = false;
         return;
@@ -76,7 +83,7 @@ void CharRingBuffer::end_line() {
     if (!lineInProgress) {
         while (count == capacity) {
             if (count == 0) break;
-            size_t second_start = (count > 1) ? offsets[(offsetStart + 1) % capacity] : end;
+            Offset second_start = (count > 1) ? offsets[(offsetStart + 1) % capacity] : end;
             start = second_start;
             offsetStart = (offsetStart + 1) % capacity;
             count--;
@@ -90,7 +97,7 @@ void CharRingBuffer::end_line() {
     }
 
     while (count == capacity) {
-        size_t second_start = (count > 1) ? offsets[(offsetStart + 1) % capacity] : end;
+        Offset second_start = (count > 1) ? offsets[(offsetStart + 1) % capacity] : end;
         start = second_start;
         offsetStart = (offsetStart + 1) % capacity;
         count--;
@@ -104,7 +111,8 @@ void CharRingBuffer::end_line() {
     lineInProgress = false;
 }
 
-void CharRingBuffer::print() const {
+template <size_t MaxBytes>
+void CharRingBuffer<MaxBytes>::print() const {
     if (count == 0) {
         return;
     }
@@ -115,21 +123,25 @@ void CharRingBuffer::print() const {
     for (size_t i = 0; i < count; ++i) {
         size_t idx = (offsetStart + i) % capacity;
         size_t nextIdx = (i + 1 < count) ? (offsetStart + i + 1) % capacity : idx;
-        size_t startPos = offsets[idx];
-        size_t endPos = (i + 1 < count) ? offsets[nextIdx] : end;
+        Offset startPos = offsets[idx];
+        Offset endPos = (i + 1 < count) ? offsets[nextIdx] : end;
 
         if (startPos <= endPos) {
-            output.append(&data[startPos], endPos - startPos);
+            output.append(&data[static_cast<size_t>(startPos)], static_cast<size_t>(endPos - startPos));
         } else {
-            output.append(&data[startPos], dataCap - startPos);
-            output.append(&data[0], endPos);
+            output.append(&data[static_cast<size_t>(startPos)], dataCap - static_cast<size_t>(startPos));
+            output.append(&data[0], static_cast<size_t>(endPos));
         }
         output.push_back('\n');
     }
     std::cout.write(output.data(), static_cast<std::streamsize>(output.size()));
 }
 
-size_t CharRingBuffer::memoryUsage() const {
-    return sizeof(CharRingBuffer) + data.size() * sizeof(char) + offsets.size() * sizeof(size_t);
+template <size_t MaxBytes>
+size_t CharRingBuffer<MaxBytes>::memoryUsage() const {
+    return sizeof(CharRingBuffer<MaxBytes>) + data.size() * sizeof(char) + offsets.size() * sizeof(Offset);
 }
+
+template class CharRingBuffer<UINT32_MAX>;
+template class CharRingBuffer<static_cast<size_t>(UINT32_MAX) + 1>;
 

--- a/src/char_ring_buffer.h
+++ b/src/char_ring_buffer.h
@@ -4,9 +4,14 @@
 #include <vector>
 #include <string>
 #include <cstddef>
+#include <cstdint>
+#include <type_traits>
 
+template <size_t MaxBytes = UINT32_MAX>
 class CharRingBuffer {
 public:
+    using Offset = std::conditional_t<MaxBytes<=UINT32_MAX,uint32_t,uint64_t>;
+
     explicit CharRingBuffer(size_t capacity, size_t lineCapacity = 0);
 
     // Existing line based API
@@ -26,14 +31,14 @@ public:
 
 private:
     std::vector<char> data;             // underlying byte storage
-    std::vector<size_t> offsets;        // ring of line start positions
+    std::vector<Offset> offsets;        // ring of line start positions
     size_t capacity;                    // maximum number of lines
-    size_t start;                       // index of first byte in data
-    size_t end;                         // index one past the last byte
+    Offset start;                       // index of first byte in data
+    Offset end;                         // index one past the last byte
     size_t offsetStart;                 // index of first entry in offsets
     size_t count;                       // current number of lines
     bool lineInProgress;                // whether a line is being built
-    size_t currentLineStart;            // start offset of current line
+    Offset currentLineStart;            // start offset of current line
 };
 
 #endif // CHAR_RING_BUFFER_H

--- a/src/circular_buffer.h
+++ b/src/circular_buffer.h
@@ -6,7 +6,7 @@
 
 #ifdef USE_CHAR_RING_BUFFER
 #include "char_ring_buffer.h"
-using CircularBuffer = CharRingBuffer;
+using CircularBuffer = CharRingBuffer<>;
 #else
 
 class CircularBuffer {

--- a/tests/test_char_ring_buffer.cpp
+++ b/tests/test_char_ring_buffer.cpp
@@ -27,3 +27,18 @@ TEST(CharRingBufferTest, EmptyBuffer) {
 
     EXPECT_EQ(output, "");
 }
+
+TEST(CharRingBufferTest, LargeBufferPromotesOffset) {
+    using BigBuffer = CharRingBuffer<static_cast<size_t>(UINT32_MAX) + 1>;
+    static_assert(sizeof(typename BigBuffer::Offset) == sizeof(uint64_t),
+                  "Offset should be 64-bit for large buffers");
+
+    BigBuffer cb(2, 1);
+    cb.append_segment("A", 1); cb.end_line();
+
+    testing::internal::CaptureStdout();
+    cb.print();
+    std::string output = testing::internal::GetCapturedStdout();
+
+    EXPECT_EQ(output, "A\n");
+}


### PR DESCRIPTION
## Summary
- parameterize `CharRingBuffer` by maximum byte size and select 32/64-bit offsets
- replace offset storage and calculations with promoted `Offset`
- add test asserting 64-bit offsets when buffer size exceeds 4GiB

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_68a857f6c528832abded28512cdb984a