### PR TITLE
Simplify tail file reading

### DIFF
--- a/src/tail_plain.cpp
+++ b/src/tail_plain.cpp
@@ -2,7 +2,6 @@
 #include <fstream>
 #include <algorithm>
 #include <stdexcept>
-#include <vector>
 
 void tailPlainFile(const std::string& filename, Parser& parser, size_t n, size_t bufferSize) {
     std::ifstream file(filename, std::ios::binary);
@@ -12,24 +11,18 @@ void tailPlainFile(const std::string& filename, Parser& parser, size_t n, size_t
 
     file.seekg(0, std::ios::end);
     std::streamoff size = file.tellg();
-    std::vector<std::string> chunks;
-    std::string chunk;
+    std::string chunk(bufferSize, '\0');
     size_t lines = 0;
 
     while (size > 0 && lines <= n) {
         size_t toRead = static_cast<size_t>(std::min<std::streamoff>(bufferSize, size));
         size -= toRead;
         file.seekg(size, std::ios::beg);
-        chunk.resize(toRead);
         file.read(&chunk[0], toRead);
-        lines += static_cast<size_t>(std::count(chunk.begin(), chunk.end(), '\n'));
-        chunks.emplace_back(std::move(chunk));
-        chunk.clear();
+        lines += static_cast<size_t>(std::count(chunk.begin(), chunk.begin() + toRead, '\n'));
+        parser.parse(chunk.data(), toRead);
         if (size == 0) break;
     }
 
-    for (auto it = chunks.rbegin(); it != chunks.rend(); ++it) {
-        parser.parse(it->data(), it->size());
-    }
     parser.finalize();
 }


### PR DESCRIPTION
## Summary
- reuse a single buffer when tailing plain files
- parse chunks immediately while scanning from the end

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a85c147b70832ab9bdb8bbb865af82