### PR TITLE
Add runtime thread control and adaptive buffer sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Library names may vary on other operating systems.
    cmake .. -DZTAIL_USE_THREADS=OFF
    ```
 
+   Threads can also be disabled at runtime with the `--no-threads` option.
+
    The high-performance CharRingBuffer backend is enabled by default. To use the previous
    std::string-based implementation for debugging, disable it with:
 
@@ -102,6 +104,7 @@ Library names may vary on other operating systems.
 - **`-n N`, `--lines N`**: Display the last N lines (default = 10).
 - **`-c N`, `--line-capacity N`**: Pre-reserve N bytes for each line to reduce reallocations (default = 0).
 - **`-r N`, `--read-buffer N`**: Set read buffer size in bytes (default = 1048576).
+- **`--no-threads`**: Disable producer/consumer threads.
 - **`file.gz`, `file.bgz`, `file.bz2`, `file.xz`, `file.zip`, or `file.zst`**: Name of the compressed file. The extension may be omitted because compression type is detected automatically.
 - **`-e <name>`, `--entry <name>`**: When reading a `.zip` file, select an entry inside the archive.
 - If no file is provided, **ztail** reads from standard input.

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -17,6 +17,7 @@ void CLI::usage(const char* progName) {
         << "  -r, --read-buffer N : set read buffer size in bytes (default = 1048576)\n"
         << "  -e, --entry <name> : entry name inside zip archive\n"
         << "      --print-aggregation-threshold N : threshold in bytes for aggregated output (default = 8388608)\n"
+        << "      --no-threads   : disable producer/consumer threading\n"
         << "  -V, --version  : display program version and exit\n"
         << "  -h, --help     : display this help and exit\n"
         << "If no file is provided, the program reads from stdin.\n"
@@ -38,6 +39,7 @@ CLIOptions CLI::parse(int argc, char* argv[]) {
         {"read-buffer",   required_argument, nullptr, 'r'},
         {"entry",         required_argument, nullptr, 'e'},
         {"print-aggregation-threshold", required_argument, nullptr, 1000},
+        {"no-threads",    no_argument,       nullptr, 1002},
         {0, 0, 0, 0}
     };
 
@@ -116,6 +118,9 @@ CLIOptions CLI::parse(int argc, char* argv[]) {
             options.bytesBudget = static_cast<size_t>(val);
             break;
         }
+        case 1002:
+            options.useThreads = false;
+            break;
         case '?':
         default:
             throw std::runtime_error("Unknown option");

--- a/src/cli.h
+++ b/src/cli.h
@@ -13,6 +13,7 @@ struct CLIOptions {
     size_t zlibBufferSize = 1 << 20; // Buffer size for zlib operations
     size_t readBufferSize = 1 << 20; // Buffer size for reading files
     size_t printAggregationThreshold = 8 * 1024 * 1024; // Threshold for block printing
+    bool useThreads = true; // Enable producer/consumer threads
 };
 
 class CLI {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,8 @@
 #include <cstdio>      // for fread
 #include <vector>
 #include <cstdlib>     // for EXIT_SUCCESS/EXIT_FAILURE
+#include <fstream>
+#include <string>
 #if ZTAIL_USE_THREADS
 #include <thread>
 #include <mutex>
@@ -25,61 +27,111 @@
 namespace {
 
 template <typename Reader>
-void processStream(Reader reader, Parser& parser, CircularBuffer& cb, size_t bufferSize, size_t aggregationThreshold) {
+void processStream(Reader reader, Parser& parser, CircularBuffer& cb,
+                   size_t bufferSize, size_t aggregationThreshold, bool useThreads) {
 #if ZTAIL_USE_THREADS
-    std::vector<char> buffers[2] = {
-        std::vector<char>(bufferSize),
-        std::vector<char>(bufferSize)
+    auto memoryLimited = [](size_t bs) {
+#if defined(__linux__)
+        std::ifstream meminfo("/proc/meminfo");
+        std::string key, unit;
+        size_t value = 0;
+        while (meminfo >> key >> value >> unit) {
+            if (key == "MemAvailable:") {
+                size_t avail = value * 1024; // value in kB
+                return bs * 2 > avail / 2; // reserve at most half of available memory
+            }
+        }
+#endif
+        return false;
     };
-    size_t sizes[2] = {0, 0};
-    bool ready[2] = {false, false};
-    bool finished = false;
-    std::mutex m;
-    std::condition_variable cv;
 
-    std::thread producer([&]() {
-        int idx = 0;
-        size_t n = 0;
-        while (reader(buffers[idx], n)) {
-            if (n > 0) {
+    bool threaded = useThreads && !memoryLimited(bufferSize);
+    if (threaded) {
+        size_t currentSize = bufferSize;
+        const size_t minSize = 64 * 1024;
+        int idleCount = 0;
+
+        std::vector<char> buffers[2] = {
+            std::vector<char>(currentSize),
+            std::vector<char>(currentSize)
+        };
+        size_t sizes[2] = {0, 0};
+        bool ready[2] = {false, false};
+        bool finished = false;
+        std::mutex m;
+        std::condition_variable cv;
+
+        std::thread producer([&]() {
+            int idx = 0;
+            size_t n = 0;
+            while (true) {
                 {
                     std::unique_lock<std::mutex> lock(m);
-                    sizes[idx] = n;
-                    ready[idx] = true;
+                    if (!ready[0] && !ready[1]) {
+                        ++idleCount;
+                        if (idleCount >= 3 && currentSize > minSize) {
+                            currentSize /= 2;
+                            for (auto &b : buffers) {
+                                std::vector<char>(currentSize).swap(b);
+                            }
+                            idleCount = 0;
+                        }
+                    } else {
+                        idleCount = 0;
+                    }
                 }
-                cv.notify_one();
-                idx ^= 1;
+                if (!reader(buffers[idx], n)) {
+                    break;
+                }
+                if (n > 0) {
+                    {
+                        std::unique_lock<std::mutex> lock(m);
+                        sizes[idx] = n;
+                        ready[idx] = true;
+                    }
+                    cv.notify_one();
+                    idx ^= 1;
+                }
             }
-        }
-        {
-            std::unique_lock<std::mutex> lock(m);
-            finished = true;
-        }
-        cv.notify_all();
-    });
+            {
+                std::unique_lock<std::mutex> lock(m);
+                finished = true;
+            }
+            cv.notify_all();
+        });
 
-    std::thread consumer([&]() {
-        int idx = 0;
-        while (true) {
-            std::unique_lock<std::mutex> lock(m);
-            cv.wait(lock, [&] { return ready[idx] || finished; });
-            if (ready[idx]) {
-                size_t n = sizes[idx];
-                ready[idx] = false;
-                lock.unlock();
-                parser.parse(buffers[idx].data(), n);
-                idx ^= 1;
-            } else if (finished) {
-                break;
+        std::thread consumer([&]() {
+            int idx = 0;
+            while (true) {
+                std::unique_lock<std::mutex> lock(m);
+                cv.wait(lock, [&] { return ready[idx] || finished; });
+                if (ready[idx]) {
+                    size_t n = sizes[idx];
+                    ready[idx] = false;
+                    lock.unlock();
+                    parser.parse(buffers[idx].data(), n);
+                    idx ^= 1;
+                } else if (finished) {
+                    break;
+                }
             }
+            parser.finalize();
+            cb.print(aggregationThreshold);
+        });
+
+        producer.join();
+        consumer.join();
+    } else {
+        std::vector<char> buf(bufferSize);
+        size_t n = 0;
+        while (reader(buf, n)) {
+            parser.parse(buf.data(), n);
         }
         parser.finalize();
         cb.print(aggregationThreshold);
-    });
-
-    producer.join();
-    consumer.join();
+    }
 #else
+    (void)useThreads;
     std::vector<char> buf(bufferSize);
     size_t n = 0;
     while (reader(buf, n)) {
@@ -122,7 +174,7 @@ int main(int argc, char* argv[]) {
                         &](std::vector<char>& buf, size_t& n) {
                             return comp->decompress(buf, n);
                         },
-                        parser, cb, options.readBufferSize, options.printAggregationThreshold);
+                        parser, cb, options.readBufferSize, options.printAggregationThreshold, options.useThreads);
                 } else {
                     det.file.reset();
                     tailPlainFile(filename, parser, options.n, options.readBufferSize);
@@ -137,7 +189,7 @@ int main(int argc, char* argv[]) {
                     n = std::fread(buf.data(), 1, buf.size(), stdin);
                     return n > 0;
                 },
-                parser, cb, options.readBufferSize, options.printAggregationThreshold);
+                parser, cb, options.readBufferSize, options.printAggregationThreshold, options.useThreads);
         }
     } catch (const std::exception& ex) {
         std::cerr << "ERROR: " << ex.what() << std::endl;


### PR DESCRIPTION
## Summary
- add `--no-threads` flag and memory check to disable producer/consumer threads when needed
- dynamically shrink read buffer as parser keeps pace to save memory
- document thread disabling option in README

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a85fb09220832aa131161b84a76cef