### PR TITLE
feat: add direct line appending to ring buffer

### DIFF
--- a/src/char_ring_buffer.h
+++ b/src/char_ring_buffer.h
@@ -22,6 +22,10 @@ public:
     // it implicitly starts that line.
     void append_segment(const char* segment, size_t len);
 
+    // Append a complete line from raw bytes.  The bytes are copied directly
+    // into the ring buffer and the line is finalized in a single step.
+    void append_line(const char* line, size_t len);
+
     // Mark the end of the current line.  The line becomes visible to print()
     // and counts toward the ring capacity.
     void end_line();

--- a/src/circular_buffer.cpp
+++ b/src/circular_buffer.cpp
@@ -58,6 +58,11 @@ void CircularBuffer::end_line() {
     current_line.clear();
 }
 
+void CircularBuffer::append_line(const char* line, size_t len) {
+    std::string tmp(line, len);
+    add(std::move(tmp));
+}
+
 void CircularBuffer::print(size_t aggregationThreshold) const {
     if (count == 0) {
         return;

--- a/src/circular_buffer.h
+++ b/src/circular_buffer.h
@@ -18,6 +18,9 @@ public:
     void append_segment(const char* segment, size_t len);
     void end_line();
 
+    // Append a complete line from raw bytes in a single step.
+    void append_line(const char* line, size_t len);
+
     void print(size_t aggregationThreshold) const;
     size_t memoryUsage() const;
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -21,11 +21,13 @@ void Parser::parse(const char* data, size_t size) {
             if (residualLen > 0) {
                 circularBuffer.append_segment(residual, residualLen);
                 residualLen = 0;
+                if (line_length > 0) {
+                    circularBuffer.append_segment(start_ptr, line_length);
+                }
+                circularBuffer.end_line();
+            } else {
+                circularBuffer.append_line(start_ptr, line_length);
             }
-            if (line_length > 0) {
-                circularBuffer.append_segment(start_ptr, line_length);
-            }
-            circularBuffer.end_line();
             pos += line_length + 1;
         } else {
             size_t copy_len = remaining;

--- a/tests/test_char_ring_buffer.cpp
+++ b/tests/test_char_ring_buffer.cpp
@@ -16,6 +16,21 @@ TEST(CharRingBufferTest, AddAndRetrieve) {
     EXPECT_EQ(output, expected);
 }
 
+TEST(CharRingBufferTest, AppendLine) {
+    CharRingBuffer cb(3, 16);
+    cb.append_line("Line 1", 6);
+    cb.append_line("Line 2", 6);
+    cb.append_line("Line 3", 6);
+    cb.append_line("Line 4", 6);
+
+    testing::internal::CaptureStdout();
+    cb.print(1024);
+    std::string output = testing::internal::GetCapturedStdout();
+
+    std::string expected = "Line 2\nLine 3\nLine 4\n";
+    EXPECT_EQ(output, expected);
+}
+
 TEST(CharRingBufferTest, EmptyBuffer) {
     CharRingBuffer cb(0);
     cb.append_segment("Line 1", 6); cb.end_line();


### PR DESCRIPTION
## Summary
- support appending whole lines directly into `CharRingBuffer`
- allow parser to copy full lines straight from read buffer to ring
- add unit test for direct `append_line`

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a863d170c4832aaf8f6481d8a51c15