### PR TITLE
build: default to x86-64-v3 with optional native arch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,8 @@ else()
 endif()
 
 # Option to build portable binaries
-option(BUILD_PORTABLE "Build without native CPU optimizations" OFF)
+option(BUILD_PORTABLE "Build without CPU-specific optimizations" OFF)
+option(USE_NATIVE "Build with -march=native" OFF)
 option(USE_CHAR_RING_BUFFER "Use CharRingBuffer instead of std::string CircularBuffer" ON)
 option(ZTAIL_USE_THREADS "Enable producer/consumer threading" ON)
 
@@ -44,8 +45,10 @@ add_compile_options(
 
 if(BUILD_PORTABLE)
     add_compile_options(-mtune=generic)
-else()
+elseif(USE_NATIVE)
     add_compile_options(-march=native)
+else()
+    add_compile_options(-march=x86-64-v3)
 endif()
 
 if(ipo_supported)

--- a/README.md
+++ b/README.md
@@ -54,12 +54,28 @@ Library names may vary on other operating systems.
    cmake .. -DBUILD_TESTING=ON
    ```
 
-   To generate a portable binary that avoids CPU-specific optimizations, enable the
-   `BUILD_PORTABLE` option:
+   By default, **ztail** compiles with `-march=x86-64-v3`, which targets most modern
+   x86-64 CPUs for a good balance of performance and portability.
 
-   ```bash
-   cmake .. -DBUILD_PORTABLE=ON
-   ```
+   - For maximum compatibility with older processors, enable the `BUILD_PORTABLE`
+     option:
+
+     ```bash
+     cmake .. -DBUILD_PORTABLE=ON
+     ```
+
+   - For the highest possible performance on the build machine, enable `USE_NATIVE`
+     to compile with `-march=native`:
+
+     ```bash
+     cmake .. -DUSE_NATIVE=ON
+     ```
+
+   Using `-march=native` can yield additional speedups by exploiting all CPU features
+   available on the host, but the resulting binary may not run on systems with
+   different processors. `-march=x86-64-v3` remains compatible with most modern
+   hardware, while `BUILD_PORTABLE` trades performance for compatibility with any
+   x86-64 CPU.
 
    On systems without thread support, disable the producer/consumer threads with:
 


### PR DESCRIPTION
## Summary
- compile for x86-64-v3 by default
- allow `-march=native` with `-DUSE_NATIVE=ON`
- document performance/compatibility trade-offs of the build options

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a865d921b4832a9ccc4d959f68f36c