### PR TITLE
feat(cli): default line capacity to 512

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Library names may vary on other operating systems.
 ```
 
 - **`-n N`, `--lines N`**: Display the last N lines (default = 10).
-- **`-c N`, `--line-capacity N`**: Pre-reserve N bytes for each line to reduce reallocations (default = 0).
+- **`-c N`, `--line-capacity N`**: Pre-reserve N bytes for each line to reduce reallocations (default = 512).
 - **`-b N`, `--zlib-buffer N`**: Set zlib buffer size in bytes (default = 1048576).
 - **`--xz-buffer N`**: Set xz buffer size in bytes (default = 32768).
 - **`--zstd-window N`**: Set maximum zstd window size in bytes (default = unlimited).

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -11,7 +11,7 @@ void CLI::usage(const char* progName) {
     std::cerr
         << "Usage: " << progName << " [options] <files...>\n"
         << "  -n, --lines N   : print the last N lines (default = 10)\n"
-        << "  -c, --line-capacity N : pre-reserve N bytes for each line\n"
+        << "  -c, --line-capacity N : pre-reserve N bytes for each line (default = 512)\n"
         << "      --bytes-budget N : limit total bytes stored for lines\n"
         << "  -b, --zlib-buffer N : set zlib buffer size in bytes (default = 1048576)\n"
         << "      --xz-buffer N   : set xz buffer size in bytes (default = 32768)\n"

--- a/src/cli.h
+++ b/src/cli.h
@@ -6,7 +6,7 @@
 
 struct CLIOptions {
     int n = 10;             // Number of lines to print (default = 10)
-    size_t lineCapacity = 0; // Optional pre-reserve size for each line
+    size_t lineCapacity = 512; // Optional pre-reserve size for each line (default = 512)
     size_t bytesBudget = 0;  // Optional total bytes budget for stored lines
     std::vector<std::string> filenames;   // Names of files to process
     std::string zipEntry;   // Optional entry name for zip files

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -148,6 +148,9 @@ int main(int argc, char* argv[]) {
     std::cout.tie(nullptr);
     try {
         CLIOptions options = CLI::parse(argc, argv);
+        if (options.lineCapacity == 0) {
+            std::cerr << "WARNING: line capacity is 0; no buffer will be preallocated for lines" << std::endl;
+        }
 
         if (!options.filenames.empty()) {
             for (const auto& filename : options.filenames) {


### PR DESCRIPTION
## Summary
- default line capacity set to 512
- document default in CLI usage and README
- warn when runtime line capacity is zero

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68a87e12d228832aa3e1826398eb0bd7